### PR TITLE
Tech CORE-309 | sidecar-server tests

### DIFF
--- a/pkg/sidecar/server/server.go
+++ b/pkg/sidecar/server/server.go
@@ -92,7 +92,7 @@ func (s *Server) Run(ctx context.Context) {
 		log.Fatal(err)
 	}
 
-	log.Println("server shutdown complete")
+	// has to be the last method called in the shutdown
 	if err = server.Shutdown(ctxShutdown); err != nil {
 		log.Fatal("error shutting down server")
 	}

--- a/pkg/sidecar/server/server.go
+++ b/pkg/sidecar/server/server.go
@@ -81,12 +81,11 @@ func (s *Server) Run(ctx context.Context) {
 
 	log.Println("gracefully shutting down...")
 
-	ctxShutdown, cancel := context.WithDeadline(context.Background(), time.Now().Add(time.Second*5))
+	ctxShutdown, cancel := context.WithDeadline(
+		context.Background(),
+		time.Now().Add(time.Second*10),
+	)
 	defer cancel()
-
-	if err = server.Shutdown(ctxShutdown); err != nil {
-		log.Fatal("error shutting down server")
-	}
 
 	err = os.RemoveAll(s.addr)
 	if err != nil {
@@ -94,7 +93,7 @@ func (s *Server) Run(ctx context.Context) {
 	}
 
 	log.Println("server shutdown complete")
-	if err == http.ErrServerClosed {
-		err = nil
+	if err = server.Shutdown(ctxShutdown); err != nil {
+		log.Fatal("error shutting down server")
 	}
 }

--- a/pkg/sidecar/server/server.go
+++ b/pkg/sidecar/server/server.go
@@ -83,7 +83,7 @@ func (s *Server) Run(ctx context.Context) {
 
 	ctxShutdown, cancel := context.WithDeadline(
 		context.Background(),
-		time.Now().Add(time.Second*10),
+		time.Now().Add(time.Second*5),
 	)
 	defer cancel()
 

--- a/pkg/sidecar/server/server_test.go
+++ b/pkg/sidecar/server/server_test.go
@@ -78,42 +78,36 @@ func TestServer_Init(t *testing.T) {
 func TestServer_Run(t *testing.T) {
 	routes := []string{"commit", "writeMessage", "readMessage"}
 	env.SetMockEnv()
+	defer env.UnsetMockEnv()
+
+	// SERVER
+	s := MockServer(nil)
+	s.Init(s.Reader, s.Writer)
+	s.addr = "./test.sock"
+
+	// starts server
+	go func() {
+		s.Run(context.Background())
+	}()
+	// gives time for the server to start up
+	time.Sleep(500 * time.Millisecond)
+
+	// mock socket
+	c := transports.NewUnixSocketClient("./test.sock")
 
 	for _, r := range routes {
 		t.Run("run_test/"+r, func(t *testing.T) {
+			resp, err := c.Post("http://unix/"+r, "", nil)
+			if err != nil {
+				t.Errorf("Failed to make post to route '%v'", r)
+				return
+			}
+			if resp.StatusCode != http.StatusBadRequest {
+				t.Errorf("route '/commit' = %v, want %v", resp.StatusCode, http.StatusBadRequest)
+			}
 
-			// SERVER
-			var wg sync.WaitGroup
-			wg.Add(1)
-			defer wg.Wait()
-
-			s := MockServer(nil)
-			s.Init(s.Reader, s.Writer)
-			s.addr = "./test.sock"
-
-			go func() {
-				s.Run(context.Background())
-			}()
-
-			go func() {
-				defer wg.Done()
-				time.Sleep(500 * time.Microsecond)
-
-				// env mock socket addr
-				c := transports.NewUnixSocketClient("./test.sock")
-
-				resp, err := c.Post("http://unix/"+r, "", nil)
-				if err != nil {
-					t.Errorf("Failed to make post to route '/commit'")
-					return
-				}
-				if resp.StatusCode != http.StatusBadRequest {
-					t.Errorf("route '/commit' = %v, want %v", resp.StatusCode, http.StatusBadRequest)
-				}
-			}()
 		})
 	}
-	env.UnsetMockEnv()
 }
 
 func TestServer_Cancel(t *testing.T) {

--- a/pkg/sidecar/server/server_test.go
+++ b/pkg/sidecar/server/server_test.go
@@ -118,6 +118,7 @@ func TestServer_Run(t *testing.T) {
 
 func TestServer_Cancel(t *testing.T) {
 	env.SetMockEnv()
+	defer env.UnsetMockEnv()
 
 	t.Run("run_test/timeout", func(t *testing.T) {
 		// SERVER
@@ -148,5 +149,4 @@ func TestServer_Cancel(t *testing.T) {
 			}
 		}()
 	})
-	env.UnsetMockEnv()
 }


### PR DESCRIPTION
… server.Shutdown as the last method executed

# Description

Kind: tech 

Section: sidecar/server

Summary: Fixing the error in which sometimes the sidecar's server tests lowered it's coverage and could cause the pipeline to break.
 
Issue link: https://inspr.atlassian.net/jira/software/projects/CORE/boards/44?selectedIssue=CORE-309

## Changelog

> List the main points of change
- server.go
- server_test.go

> Important notes
- i couldn't confirm that the error is not happening anymore. What i decided to after revising the tests was to run all tests many times. Did not report an error in any of the 50+ times i ran them.
- the branch name is wrong in a mistake made earlier by me, was supposed to be CORE-309  but the branch was names CORE-308
