### PR TITLE
Issue CORE-332 | authentication field creation and injection

### DIFF
--- a/cmd/insprd/memory/tree/dapp_utils.go
+++ b/cmd/insprd/memory/tree/dapp_utils.go
@@ -57,11 +57,7 @@ func (amm *AppMemoryManager) checkApp(app, parentApp *meta.App) error {
 	return nil
 }
 
-func (amm *AppMemoryManager) addAppInTree(app, parentApp *meta.App) {
-	if parentApp.Spec.Apps == nil {
-		parentApp.Spec.Apps = make(map[string]*meta.App)
-	}
-	parentStr := getParentString(app, parentApp)
+func (amm *AppMemoryManager) updateUUID(app *meta.App, parentStr string) {
 
 	app.Meta.Parent = parentStr
 	query, _ := metautils.JoinScopes(parentStr, app.Meta.Name)
@@ -107,7 +103,17 @@ func (amm *AppMemoryManager) addAppInTree(app, parentApp *meta.App) {
 			al.Meta = metautils.InjectUUID(al.Meta)
 		}
 	}
+}
 
+func (amm *AppMemoryManager) addAppInTree(app, parentApp *meta.App) {
+	if parentApp.Spec.Apps == nil {
+		parentApp.Spec.Apps = make(map[string]*meta.App)
+	}
+	parentStr := getParentString(app, parentApp)
+	amm.updateUUID(app, parentStr)
+	if app.Spec.Auth.Permissions == nil {
+		app.Spec.Auth = parentApp.Spec.Auth
+	}
 	for _, child := range app.Spec.Apps {
 		amm.addAppInTree(child, app)
 	}

--- a/cmd/insprd/memory/tree/manager.go
+++ b/cmd/insprd/memory/tree/manager.go
@@ -47,6 +47,10 @@ func newTreeMemory() *MemoryManager {
 				Channels:     map[string]*meta.Channel{},
 				ChannelTypes: map[string]*meta.ChannelType{},
 				Aliases:      map[string]*meta.Alias{},
+				Auth: meta.AppAuth{
+					Scope:       "",
+					Permissions: nil,
+				},
 			},
 		},
 	}

--- a/pkg/meta/dapp.go
+++ b/pkg/meta/dapp.go
@@ -35,10 +35,17 @@ type AppBoundary struct {
 //
 // The boundary represent the possible connections to other apps, and the fields that can be overriten when instantiating the app.
 type AppSpec struct {
-	Node         Node                    `yaml:"node,omitempty" json:"node"`
-	Apps         map[string]*App         `yaml:"apps,omitempty" json:"apps"`
-	Channels     map[string]*Channel     `yaml:"channels,omitempty" json:"channels"`
-	ChannelTypes map[string]*ChannelType `yaml:"channeltypes,omitempty" json:"channeltypes"`
-	Aliases      map[string]*Alias       `yaml:"aliases" json:"aliases"`
-	Boundary     AppBoundary             `yaml:"boundary,omitempty" json:"boundary"`
+	Node         Node                    `yaml:"node,omitempty"   json:"node"`
+	Apps         map[string]*App         `yaml:"apps,omitempty"   json:"apps"`
+	Channels     map[string]*Channel     `yaml:"channels,omitempty"   json:"channels"`
+	ChannelTypes map[string]*ChannelType `yaml:"channeltypes,omitempty"   json:"channel_types"`
+	Aliases      map[string]*Alias       `yaml:"aliases"   json:"aliases"`
+	Boundary     AppBoundary             `yaml:"boundary,omitempty"   json:"boundary"`
+	Auth         AppAuth                 `yaml:"auth"  json:"auth"`
+}
+
+// AppAuth represents the permissions that a dApp (and its sons) contains
+type AppAuth struct {
+	Scope       string            `yaml:"scope"  json:"scope"`
+	Permissions utils.StringArray `yaml:"permissions"  json:"permissions"`
 }


### PR DESCRIPTION
# Description

Kind: feature

Section: metadata, dapp controller

Summary: creates a field for auth and injects it on dapp creation

Issue link: https://inspr.atlassian.net/browse/CORE-332?atlOrigin=eyJpIjoiNGQ1ODJmYTc4OTA0NDgxOGIyOGU4NmUwYWExYjMwYTkiLCJwIjoiaiJ9

## Changelog

- creates the field on meta
- injects on dapp creation
- tests uid injection
