### PR TITLE
Issue CORE-305 | Persist the token

### DIFF
--- a/cmd/inspr/cli/apply_alias_test.go
+++ b/cmd/inspr/cli/apply_alias_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestNewApplyAlias(t *testing.T) {
+	prepareToken(t)
 	chanWithoutNameBytes, _ := yaml.Marshal(meta.Alias{})
 	chanDefaultBytes, _ := yaml.Marshal(meta.Alias{Meta: meta.Metadata{Name: "mock"}})
 	type args struct {

--- a/cmd/inspr/cli/apply_channel_test.go
+++ b/cmd/inspr/cli/apply_channel_test.go
@@ -11,6 +11,7 @@ import (
 )
 
 func TestNewApplyChannel(t *testing.T) {
+	prepareToken(t)
 	chanWithoutNameBytes, _ := yaml.Marshal(meta.Channel{})
 	chanDefaultBytes, _ := yaml.Marshal(meta.Channel{Meta: meta.Metadata{Name: "mock"}})
 	type args struct {

--- a/cmd/inspr/cli/apply_channel_type_test.go
+++ b/cmd/inspr/cli/apply_channel_type_test.go
@@ -22,6 +22,7 @@ func createSchema() string {
 }
 
 func TestNewApplyChannelType(t *testing.T) {
+	prepareToken(t)
 	chanTypeWithoutNameBytes, _ := yaml.Marshal(meta.ChannelType{})
 	chanTypeDefaultBytes, _ := yaml.Marshal(meta.ChannelType{Meta: meta.Metadata{Name: "mock"}})
 	type args struct {
@@ -75,6 +76,7 @@ func TestNewApplyChannelType(t *testing.T) {
 }
 
 func Test_schemaNeedsInjection(t *testing.T) {
+	prepareToken(t)
 	yamlString := createSchema()
 	// creates a file with the expected syntax
 	ioutil.WriteFile(
@@ -117,6 +119,7 @@ func Test_schemaNeedsInjection(t *testing.T) {
 }
 
 func Test_injectSchema(t *testing.T) {
+	prepareToken(t)
 	yamlString := createSchema()
 	// creates a file with the expected syntax
 	ioutil.WriteFile(

--- a/cmd/inspr/cli/apply_dapp_test.go
+++ b/cmd/inspr/cli/apply_dapp_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestNewApplyApp(t *testing.T) {
+	prepareToken(t)
 	appWithoutNameBytes, _ := yaml.Marshal(meta.App{})
 	appDefaultBytes, _ := yaml.Marshal(meta.App{Meta: meta.Metadata{Name: "mock"}})
 	type args struct {
@@ -65,6 +66,7 @@ func TestNewApplyApp(t *testing.T) {
 }
 
 func Test_schemaInjection(t *testing.T) {
+	prepareToken(t)
 	type args struct {
 		ctypes map[string]*meta.ChannelType
 	}
@@ -98,6 +100,7 @@ func Test_schemaInjection(t *testing.T) {
 }
 
 func Test_recursiveSchemaInjection(t *testing.T) {
+	prepareToken(t)
 	type args struct {
 		apps map[string]*meta.App
 	}

--- a/cmd/inspr/cli/apply_test.go
+++ b/cmd/inspr/cli/apply_test.go
@@ -76,6 +76,7 @@ func getCurrentFilesInFolder() []string {
 // TestNewApplyCmd is mainly for improving test coverage,
 // it was really tested by instantiating Inspr's CLI
 func TestNewApplyCmd(t *testing.T) {
+	prepareToken(t)
 	tests := []struct {
 		name string
 	}{
@@ -94,6 +95,7 @@ func TestNewApplyCmd(t *testing.T) {
 }
 
 func Test_isYaml(t *testing.T) {
+	prepareToken(t)
 	type args struct {
 		file string
 	}
@@ -134,6 +136,7 @@ func Test_isYaml(t *testing.T) {
 }
 
 func Test_printAppliedFiles(t *testing.T) {
+	prepareToken(t)
 	type args struct {
 		appliedFiles []applied
 	}
@@ -168,6 +171,7 @@ func Test_printAppliedFiles(t *testing.T) {
 }
 
 func Test_doApply(t *testing.T) {
+	prepareToken(t)
 	defer os.Remove(filePath)
 	yamlString := createDAppYaml()
 
@@ -238,6 +242,7 @@ func Test_doApply(t *testing.T) {
 }
 
 func Test_getFilesFromFolder(t *testing.T) {
+	prepareToken(t)
 	type args struct {
 		path string
 	}
@@ -279,6 +284,7 @@ func Test_getFilesFromFolder(t *testing.T) {
 }
 
 func Test_applyValidFiles(t *testing.T) {
+	prepareToken(t)
 	defer os.Remove(filePath)
 	tempFiles := []string{filePath}
 	yamlString := createDAppYaml()
@@ -337,6 +343,7 @@ func Test_applyValidFiles(t *testing.T) {
 }
 
 func Test_getOrderedFiles(t *testing.T) {
+	prepareToken(t)
 	defer os.Remove("app.yml")
 	defer os.Remove("ch.yml")
 	defer os.Remove("ct.yml")

--- a/cmd/inspr/cli/cli_test.go
+++ b/cmd/inspr/cli/cli_test.go
@@ -11,6 +11,7 @@ import (
 // TestNewInsprCommand is mainly for improving test coverage,
 // it was really tested by instantiating Inspr's CLI
 func TestNewInsprCommand(t *testing.T) {
+	prepareToken(t)
 	tests := []struct {
 		name string
 	}{
@@ -31,6 +32,7 @@ func TestNewInsprCommand(t *testing.T) {
 }
 
 func Test_mainCmdPreRun(t *testing.T) {
+	prepareToken(t)
 	folder := t.TempDir()
 	prev := os.Getenv("HOME")
 	os.Setenv("HOME", folder)

--- a/cmd/inspr/cli/config_cmd_test.go
+++ b/cmd/inspr/cli/config_cmd_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestNewConfigChangeCmd(t *testing.T) {
+	prepareToken(t)
 	tests := []struct {
 		name          string
 		checkFunction func(t *testing.T, got *cobra.Command)
@@ -37,6 +38,7 @@ func TestNewConfigChangeCmd(t *testing.T) {
 }
 
 func TestNewListConfig(t *testing.T) {
+	prepareToken(t)
 	tests := []struct {
 		name          string
 		checkFunction func(t *testing.T, got *cobra.Command)
@@ -61,6 +63,7 @@ func TestNewListConfig(t *testing.T) {
 }
 
 func Test_doConfigChange(t *testing.T) {
+	prepareToken(t)
 	defer deleteMockViper()
 	mockViper()
 
@@ -109,6 +112,7 @@ func Test_doConfigChange(t *testing.T) {
 }
 
 func Test_doListConfig(t *testing.T) {
+	prepareToken(t)
 	bufResp := bytes.NewBufferString("")
 	cliutils.SetOutput(bufResp)
 	printExistingKeys()

--- a/cmd/inspr/cli/delete_test.go
+++ b/cmd/inspr/cli/delete_test.go
@@ -319,6 +319,7 @@ func getMockAppWithoutAlias() *meta.App {
 }
 
 func TestNewDeleteCmd(t *testing.T) {
+	prepareToken(t)
 	defer restartScopeFlag()
 	tests := []struct {
 		name          string
@@ -344,6 +345,7 @@ func TestNewDeleteCmd(t *testing.T) {
 }
 
 func Test_deleteApps(t *testing.T) {
+	prepareToken(t)
 	defer restartScopeFlag()
 	bufResp := bytes.NewBufferString("")
 	changelog, _ := diff.Diff(getMockApp(), getMockAppWithoutApp1())
@@ -423,6 +425,7 @@ func Test_deleteApps(t *testing.T) {
 }
 
 func Test_deleteChannels(t *testing.T) {
+	prepareToken(t)
 	defer restartScopeFlag()
 	bufResp := bytes.NewBufferString("")
 	changelog, _ := diff.Diff(getMockApp(), getMockAppWithoutCh1())
@@ -502,6 +505,7 @@ func Test_deleteChannels(t *testing.T) {
 }
 
 func Test_deleteCTypes(t *testing.T) {
+	prepareToken(t)
 	defer restartScopeFlag()
 	bufResp := bytes.NewBufferString("")
 	changelog, _ := diff.Diff(getMockApp(), getMockAppWithoutCt1())
@@ -581,6 +585,7 @@ func Test_deleteCTypes(t *testing.T) {
 }
 
 func Test_deleteAlias(t *testing.T) {
+	prepareToken(t)
 	defer restartScopeFlag()
 	bufResp := bytes.NewBufferString("")
 	changelog, _ := diff.Diff(getMockApp(), getMockAppWithoutAlias())

--- a/cmd/inspr/cli/describe_test.go
+++ b/cmd/inspr/cli/describe_test.go
@@ -7,6 +7,8 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 
@@ -21,6 +23,16 @@ import (
 
 func restartScopeFlag() {
 	cmd.InsprOptions.Scope = ""
+}
+
+func prepareToken(t *testing.T) {
+	dir := t.TempDir()
+	ioutil.WriteFile(
+		filepath.Join(dir, "token"),
+		[]byte("Bearer mock_token"),
+		os.ModePerm,
+	)
+	cmd.InsprOptions.Token = filepath.Join(dir, "token")
 }
 
 func getMockApp() *meta.App {
@@ -133,6 +145,7 @@ func getMockApp() *meta.App {
 }
 
 func TestNewDescribeCmd(t *testing.T) {
+	prepareToken(t)
 	defer restartScopeFlag()
 	tests := []struct {
 		name          string
@@ -158,6 +171,7 @@ func TestNewDescribeCmd(t *testing.T) {
 }
 
 func Test_displayAppState(t *testing.T) {
+	prepareToken(t)
 	defer restartScopeFlag()
 	bufResp := bytes.NewBufferString("")
 	utils.PrintAppTree(getMockApp(), bufResp)
@@ -232,6 +246,7 @@ func Test_displayAppState(t *testing.T) {
 }
 
 func Test_displayChannelState(t *testing.T) {
+	prepareToken(t)
 	defer restartScopeFlag()
 	bufResp := bytes.NewBufferString("")
 	utils.PrintChannelTree(getMockApp().Spec.Channels["ch1"], bufResp)
@@ -306,10 +321,12 @@ func Test_displayChannelState(t *testing.T) {
 }
 
 func Test_displayChannelTypeState(t *testing.T) {
+	prepareToken(t)
 	defer restartScopeFlag()
 	bufResp := bytes.NewBufferString("")
 	utils.PrintChannelTypeTree(getMockApp().Spec.ChannelTypes["ct1"], bufResp)
 	outResp, _ := ioutil.ReadAll(bufResp)
+	prepareToken(t)
 
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		data := models.ChannelTypeQueryDI{}
@@ -380,6 +397,7 @@ func Test_displayChannelTypeState(t *testing.T) {
 }
 
 func Test_displayAlias(t *testing.T) {
+	prepareToken(t)
 	defer restartScopeFlag()
 	bufResp := bytes.NewBufferString("")
 	utils.PrintAliasTree(getMockApp().Spec.Aliases["alias_name"], bufResp)

--- a/cmd/inspr/cli/get_test.go
+++ b/cmd/inspr/cli/get_test.go
@@ -21,6 +21,7 @@ import (
 )
 
 func TestNewGetCmd(t *testing.T) {
+	prepareToken(t)
 	tests := []struct {
 		name          string
 		checkFunction func(t *testing.T, got *cobra.Command)
@@ -45,6 +46,7 @@ func TestNewGetCmd(t *testing.T) {
 }
 
 func Test_getApps(t *testing.T) {
+	prepareToken(t)
 	bufResp := bytes.NewBufferString("")
 	tabWriter := tabwriter.NewWriter(bufResp, 0, 0, 3, ' ', tabwriter.AlignRight|tabwriter.Debug)
 	fmt.Fprint(tabWriter, "NAME\n")
@@ -115,6 +117,7 @@ func Test_getApps(t *testing.T) {
 }
 
 func Test_getChannels(t *testing.T) {
+	prepareToken(t)
 	bufResp := bytes.NewBufferString("")
 	tabWriter := tabwriter.NewWriter(bufResp, 0, 0, 3, ' ', tabwriter.AlignRight|tabwriter.Debug)
 	fmt.Fprint(tabWriter, "NAME\n")
@@ -184,6 +187,7 @@ func Test_getChannels(t *testing.T) {
 }
 
 func Test_getCTypes(t *testing.T) {
+	prepareToken(t)
 	bufResp := bytes.NewBufferString("")
 	tabWriter := tabwriter.NewWriter(bufResp, 0, 0, 3, ' ', tabwriter.AlignRight|tabwriter.Debug)
 	fmt.Fprint(tabWriter, "NAME\n")
@@ -252,6 +256,7 @@ func Test_getCTypes(t *testing.T) {
 }
 
 func Test_getNodes(t *testing.T) {
+	prepareToken(t)
 
 	bufResp := bytes.NewBufferString("")
 	tabWriter := tabwriter.NewWriter(bufResp, 0, 0, 3, ' ', tabwriter.AlignRight|tabwriter.Debug)
@@ -321,6 +326,7 @@ func Test_getNodes(t *testing.T) {
 }
 
 func Test_getObj(t *testing.T) {
+	prepareToken(t)
 	type args struct {
 		printObj func(*meta.App, *[]string)
 		lines    *[]string
@@ -382,6 +388,7 @@ func Test_getObj(t *testing.T) {
 }
 
 func Test_printApps(t *testing.T) {
+	prepareToken(t)
 	type args struct {
 		app   *meta.App
 		lines *[]string
@@ -411,6 +418,7 @@ func Test_printApps(t *testing.T) {
 }
 
 func Test_printChannels(t *testing.T) {
+	prepareToken(t)
 	type args struct {
 		app   *meta.App
 		lines *[]string
@@ -440,6 +448,7 @@ func Test_printChannels(t *testing.T) {
 }
 
 func Test_printCTypes(t *testing.T) {
+	prepareToken(t)
 	type args struct {
 		app   *meta.App
 		lines *[]string
@@ -469,6 +478,7 @@ func Test_printCTypes(t *testing.T) {
 }
 
 func Test_printNodes(t *testing.T) {
+	prepareToken(t)
 	type args struct {
 		app   *meta.App
 		lines *[]string
@@ -498,6 +508,7 @@ func Test_printNodes(t *testing.T) {
 }
 
 func Test_printLine(t *testing.T) {
+	prepareToken(t)
 	type args struct {
 		name  string
 		lines *[]string
@@ -527,6 +538,7 @@ func Test_printLine(t *testing.T) {
 }
 
 func Test_initTab(t *testing.T) {
+	prepareToken(t)
 	type args struct {
 		lines *[]string
 	}
@@ -554,6 +566,7 @@ func Test_initTab(t *testing.T) {
 }
 
 func Test_printTab(t *testing.T) {
+	prepareToken(t)
 	bufResp := bytes.NewBufferString("")
 	tabWriter := tabwriter.NewWriter(bufResp, 0, 0, 3, ' ', tabwriter.AlignRight|tabwriter.Debug)
 
@@ -593,6 +606,7 @@ func Test_printTab(t *testing.T) {
 }
 
 func Test_printAliases(t *testing.T) {
+	prepareToken(t)
 	type args struct {
 		app   *meta.App
 		lines *[]string
@@ -622,6 +636,7 @@ func Test_printAliases(t *testing.T) {
 }
 
 func Test_getAlias(t *testing.T) {
+	prepareToken(t)
 	bufResp := bytes.NewBufferString("")
 	tabWriter := tabwriter.NewWriter(bufResp, 0, 0, 3, ' ', tabwriter.AlignRight|tabwriter.Debug)
 	fmt.Fprint(tabWriter, "NAME\n")

--- a/pkg/cmd/utils/auth.go
+++ b/pkg/cmd/utils/auth.go
@@ -5,14 +5,18 @@ import (
 	"os"
 )
 
+// Authenticator is responsible for implementing the interface methods
+// defined in the rest/request pkg.
 type Authenticator struct {
-	tokenPath string
+	TokenPath string
 }
 
 var bearer = []byte("Bearer ")
 
+// GetToken read the token from the file specified in the struct
+// TokenPath and returns it's bytes
 func (a Authenticator) GetToken() ([]byte, error) {
-	token, err := ioutil.ReadFile(a.tokenPath)
+	token, err := ioutil.ReadFile(a.TokenPath)
 	if err != nil {
 		return nil, err
 	}
@@ -20,9 +24,11 @@ func (a Authenticator) GetToken() ([]byte, error) {
 	return token, nil
 }
 
+// SetToken receives a new token as a parameter and then writes it
+// in the file specified in the TokenPath
 func (a Authenticator) SetToken(token []byte) error {
 	token = token[len(bearer):]
-	err := ioutil.WriteFile(a.tokenPath, token, os.ModePerm)
+	err := ioutil.WriteFile(a.TokenPath, token, os.ModePerm)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/utils/auth.go
+++ b/pkg/cmd/utils/auth.go
@@ -1,0 +1,30 @@
+package utils
+
+import (
+	"io/ioutil"
+	"os"
+)
+
+type Authenticator struct {
+	tokenPath string
+}
+
+var bearer = []byte("Bearer ")
+
+func (a Authenticator) GetToken() ([]byte, error) {
+	token, err := ioutil.ReadFile(a.tokenPath)
+	if err != nil {
+		return nil, err
+	}
+	token = append(bearer, token...)
+	return token, nil
+}
+
+func (a Authenticator) SetToken(token []byte) error {
+	token = token[len(bearer):]
+	err := ioutil.WriteFile(a.tokenPath, token, os.ModePerm)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/cmd/utils/auth_test.go
+++ b/pkg/cmd/utils/auth_test.go
@@ -9,9 +9,7 @@ import (
 )
 
 func TestAuthenticator_GetToken(t *testing.T) {
-	os.Mkdir("./temp", os.ModePerm)
-	folder := "./temp"
-	defer os.RemoveAll("./temp")
+	folder := t.TempDir()
 
 	type fields struct {
 		TokenPath string
@@ -68,9 +66,7 @@ func TestAuthenticator_GetToken(t *testing.T) {
 }
 
 func TestAuthenticator_SetToken(t *testing.T) {
-	os.Mkdir("./temp", os.ModePerm)
-	folder := "./temp"
-	defer os.RemoveAll("./temp")
+	folder := t.TempDir()
 
 	type fields struct {
 		TokenPath string

--- a/pkg/cmd/utils/auth_test.go
+++ b/pkg/cmd/utils/auth_test.go
@@ -1,0 +1,63 @@
+package utils
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestAuthenticator_GetToken(t *testing.T) {
+	os.Mkdir("./temp", os.ModePerm)
+	folder := "./temp"
+	defer os.RemoveAll("./temp")
+	type fields struct {
+		tokenPath string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		want    []byte
+		wantErr bool
+		before  func(auth Authenticator)
+	}{
+		{
+			name: "valid token location",
+			fields: fields{
+				tokenPath: filepath.Join(folder, "token"),
+			},
+			want:    []byte("Bearer this is a token"),
+			wantErr: false,
+			before: func(auth Authenticator) {
+				ioutil.WriteFile(filepath.Join(folder, "token"), []byte("this is a token"), os.ModePerm)
+			},
+		},
+		{
+			name: "invalid token location",
+			fields: fields{
+				tokenPath: filepath.Join(folder, "token2"),
+			},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := Authenticator{
+				tokenPath: tt.fields.tokenPath,
+			}
+			if tt.before != nil {
+				tt.before(a)
+			}
+			got, err := a.GetToken()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Authenticator.GetToken() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Authenticator.GetToken() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/cmd/utils/cli_client.go
+++ b/pkg/cmd/utils/cli_client.go
@@ -50,7 +50,9 @@ func SetOutput(out io.Writer) {
 
 // SetClient sets the default server IP of CLI
 func SetClient(url string) {
-	defaults.client = client.NewControllerClient(url, GetToken(cmd.InsprOptions.Token))
+	defaults.client = client.NewControllerClient(url, Authenticator{
+		cmd.InsprOptions.Token,
+	})
 }
 
 //SetMockedClient configures singleton's client as a mocked client given a error

--- a/pkg/controller/client/client.go
+++ b/pkg/controller/client/client.go
@@ -13,8 +13,8 @@ type Client struct {
 }
 
 // NewControllerClient return a new Client
-func NewControllerClient(url string, token []byte) controller.Interface {
-	client := request.NewClient().BaseURL(url).Encoder(json.Marshal).Decoder(request.JSONDecoderGenerator).Token(token).Build()
+func NewControllerClient(url string, auth request.Authenticator) controller.Interface {
+	client := request.NewClient().BaseURL(url).Encoder(json.Marshal).Decoder(request.JSONDecoderGenerator).Authenticator(auth).Build()
 	return &Client{
 		HTTPClient: client,
 	}

--- a/pkg/controller/client/client_test.go
+++ b/pkg/controller/client/client_test.go
@@ -32,7 +32,7 @@ func TestNewControllerClient(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := NewControllerClient(tt.args.url, tt.args.token)
+			got := NewControllerClient(tt.args.url, nil)
 
 			if reflect.TypeOf(got) != reflect.TypeOf(tt.want) {
 				t.Errorf(

--- a/pkg/rest/request/builder.go
+++ b/pkg/rest/request/builder.go
@@ -6,6 +6,12 @@ import (
 	"net/http"
 )
 
+// Authenticator is an interface to perform authentication via tokens
+type Authenticator interface {
+	GetToken() ([]byte, error)
+	SetToken([]byte) error
+}
+
 // ClientBuilder builds a client with the given specifications
 type ClientBuilder struct {
 	c *Client
@@ -23,15 +29,22 @@ func (cb *ClientBuilder) Encoder(encoder Encoder) *ClientBuilder {
 	return cb
 }
 
-// Token adds a token header with the format "Authentication: Bearer " + token on each request the client sends.
-func (cb *ClientBuilder) Token(token []byte) *ClientBuilder {
-	return cb.Header("Authentication", fmt.Sprintf("Bearer %s", token))
-}
-
 // Decoder sets the decoder for the client that is being built
 func (cb *ClientBuilder) Decoder(decoder DecoderGenerator) *ClientBuilder {
 	cb.c.decoderGenerator = decoder
 	return cb
+}
+
+// Authenticator adds the authentication interface implementation to the
+// Client strucuture.
+func (cb *ClientBuilder) Authenticator(au Authenticator) *ClientBuilder {
+	cb.c.auth = au
+	return cb
+}
+
+// Token adds a token header with the format "Authentication: Bearer " + token on each request the client sends.
+func (cb *ClientBuilder) Token(token []byte) *ClientBuilder {
+	return cb.Header("Authentication", fmt.Sprintf("Bearer %s", token))
 }
 
 // HTTPClient sets the http client for the client that is being built
@@ -67,16 +80,5 @@ func (cb *ClientBuilder) Header(key, value string) *ClientBuilder {
 		cb.c.headers = make(map[string]string)
 	}
 	cb.c.headers[key] = value
-	return cb
-}
-
-// Authenticator is an interface to perform authentication via tokens
-type Authenticator interface {
-	GetToken() ([]byte, error)
-	SetToken([]byte) error
-}
-
-func (cb *ClientBuilder) Authenticator(au Authenticator) *ClientBuilder {
-	cb.c.auth = au
 	return cb
 }

--- a/pkg/rest/request/builder.go
+++ b/pkg/rest/request/builder.go
@@ -69,3 +69,14 @@ func (cb *ClientBuilder) Header(key, value string) *ClientBuilder {
 	cb.c.headers[key] = value
 	return cb
 }
+
+// Authenticator is an interface to perform authentication via tokens
+type Authenticator interface {
+	GetToken() ([]byte, error)
+	SetToken([]byte) error
+}
+
+func (cb *ClientBuilder) Authenticator(au Authenticator) *ClientBuilder {
+	cb.c.auth = au
+	return cb
+}

--- a/pkg/rest/request/builder_test.go
+++ b/pkg/rest/request/builder_test.go
@@ -276,3 +276,144 @@ func TestNewJSONClient(t *testing.T) {
 		})
 	}
 }
+
+func TestClientBuilder_Authenticator(t *testing.T) {
+	type fields struct {
+		c *Client
+	}
+	type args struct {
+		au Authenticator
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantNil bool
+	}{
+		{
+			name: "received_auth",
+			fields: fields{
+				c: &Client{},
+			},
+			args: args{
+				au: mockAuth{err: nil},
+			},
+			wantNil: false,
+		},
+		{
+			name: "nil_auth",
+			fields: fields{
+				c: &Client{},
+			},
+			args:    args{au: nil},
+			wantNil: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cb := &ClientBuilder{
+				c: tt.fields.c,
+			}
+
+			got := cb.Authenticator(tt.args.au)
+
+			condition := (reflect.TypeOf(got.c.auth) == reflect.TypeOf(nil))
+
+			if condition != tt.wantNil {
+				t.Errorf(
+					"ClientBuilder.Authenticator() = %v, want nil => %v",
+					reflect.TypeOf(got.c.auth),
+					tt.wantNil,
+				)
+			}
+		})
+	}
+}
+
+func TestClientBuilder_Token(t *testing.T) {
+	type fields struct {
+		c *Client
+	}
+	type args struct {
+		token []byte
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   map[string]string
+	}{
+		{
+			name: "basic_test_Token",
+			fields: fields{
+				c: &Client{},
+			},
+			args: args{
+				token: []byte("mock_token"),
+			},
+			want: map[string]string{
+				"Authentication": "Bearer mock_token",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cb := &ClientBuilder{
+				c: tt.fields.c,
+			}
+			got := cb.Token(tt.args.token)
+			if !reflect.DeepEqual(got.c.headers, tt.want) {
+				t.Errorf(
+					"ClientBuilder.Token() = %v, want %v",
+					got.c.headers,
+					tt.want,
+				)
+			}
+		})
+	}
+}
+
+func TestClientBuilder_Header(t *testing.T) {
+	type fields struct {
+		c *Client
+	}
+	type args struct {
+		key   string
+		value string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   map[string]string
+	}{
+		{
+			name: "header_inserted_values",
+			fields: fields{
+				c: &Client{},
+			},
+			args: args{
+				key:   "key",
+				value: "Bearer token",
+			},
+			want: map[string]string{
+				"key": "Bearer token",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cb := &ClientBuilder{
+				c: tt.fields.c,
+			}
+			got := cb.Header(tt.args.key, tt.args.value)
+			if !reflect.DeepEqual(got.c.headers, tt.want) {
+				t.Errorf(
+					"ClientBuilder.Header() = %v, want %v",
+					got.c.headers,
+					tt.want,
+				)
+			}
+		})
+	}
+}

--- a/pkg/rest/request/builder_test.go
+++ b/pkg/rest/request/builder_test.go
@@ -296,7 +296,10 @@ func TestClientBuilder_Authenticator(t *testing.T) {
 				c: &Client{},
 			},
 			args: args{
-				au: mockAuth{err: nil},
+				au: mockAuth{
+					errGet: nil,
+					errSet: nil,
+				},
 			},
 			wantNil: false,
 		},

--- a/pkg/rest/request/mocks.go
+++ b/pkg/rest/request/mocks.go
@@ -1,0 +1,19 @@
+package request
+
+type mockAuth struct {
+	err error
+}
+
+func (ma mockAuth) GetToken() ([]byte, error) {
+	if ma.err != nil {
+		return []byte{}, ma.err
+	}
+	return []byte("bearer mock_token"), nil
+}
+
+func (ma mockAuth) SetToken([]byte) error {
+	if ma.err != nil {
+		return ma.err
+	}
+	return nil
+}

--- a/pkg/rest/request/mocks.go
+++ b/pkg/rest/request/mocks.go
@@ -1,19 +1,20 @@
 package request
 
 type mockAuth struct {
-	err error
+	errGet error
+	errSet error
 }
 
 func (ma mockAuth) GetToken() ([]byte, error) {
-	if ma.err != nil {
-		return []byte{}, ma.err
+	if ma.errGet != nil {
+		return []byte{}, ma.errGet
 	}
 	return []byte("bearer mock_token"), nil
 }
 
 func (ma mockAuth) SetToken([]byte) error {
-	if ma.err != nil {
-		return ma.err
+	if ma.errSet != nil {
+		return ma.errSet
 	}
 	return nil
 }

--- a/pkg/rest/request/request.go
+++ b/pkg/rest/request/request.go
@@ -46,7 +46,8 @@ func (c *Client) Send(ctx context.Context, route string, method string, body int
 		return err
 	}
 
-	if updatedToken := resp.Header.Get("Authorization"); c.auth != nil && updatedToken != "" {
+	updatedToken := resp.Header.Get("Authorization")
+	if c.auth != nil && updatedToken != "" {
 		err := c.auth.SetToken([]byte(updatedToken))
 		if err != nil {
 			return ierrors.NewError().BadRequest().Message("unable to update token").InnerError(err).Build()


### PR DESCRIPTION
# Description

Kind: issue

Section: pkg/rest/request | cmd/inspr/cli

Summary: Get the token from either a file specified via the user CLI with a --token flag or a default location, inside the inspr folder on the user’s system

Issue link: https://inspr.atlassian.net/browse/CORE-305

