### PR TITLE
Feature: adds init command for config initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,16 @@
 # Changelog
+### #48 - Feature: adds init command to the cli
+
+- features:
+    - creates an init command for configuration initialization
+    - adds config flag to specify configuration file
+    - changes flow so that if the config is invalid, asks for initialization
+- refactors:
+    - refactors configuration initialization to allow different files
+    - changes command builder to now use variadic flag argument instead of slice
+- fix:
+    - silences main command to remove duplicate errors
+
 
 ### #41 - Feature: Handling invalid requests in the middleware authorization
 - features:

--- a/cmd/inspr/cli/apply.go
+++ b/cmd/inspr/cli/apply.go
@@ -60,7 +60,7 @@ It can be called with the flag --dry-run so the changes that would be made are s
 				FlagAddMethod: "BoolVar",
 				DefinedOn:     []string{"apply"},
 			},
-		}).
+		}...).
 		NoArgs(doApply)
 
 	applyCmd.MarkFlagFilename("file", "yaml", "yml")

--- a/cmd/inspr/cli/apply_test.go
+++ b/cmd/inspr/cli/apply_test.go
@@ -338,7 +338,7 @@ func Test_applyValidFiles(t *testing.T) {
 			},
 			want:    nil,
 			funcErr: ierrors.NewError().Message("unauthorized").Unauthorized().Build(),
-			errMsg:  "did you login ?\n",
+			errMsg:  "We couldn't authenticate with the cluster. Is your token configured correctly?\n",
 		},
 		{
 			name: "forbidden_error",

--- a/cmd/inspr/cli/cli.go
+++ b/cmd/inspr/cli/cli.go
@@ -48,7 +48,7 @@ func mainCmdPreRun(cm *cobra.Command, args []string) error {
 		err = utils.ReadConfigFromFile(cmd.InsprOptions.Config)
 	}
 	if err != nil {
-		fmt.Fprintf(utils.GetCliOutput(), "Invalid config file! Did you run inspr init?")
+		fmt.Fprintln(utils.GetCliOutput(), "Invalid config file! Did you run inspr init?")
 	}
-	return nil
+	return err
 }

--- a/cmd/inspr/cli/cli.go
+++ b/cmd/inspr/cli/cli.go
@@ -34,7 +34,7 @@ func NewInsprCommand(out, err io.Writer, version string) *cobra.Command {
 }
 
 func mainCmdPreRun(cm *cobra.Command, args []string) error {
-	if cm.Name() == "init" {
+	if cm.Name() == "init" && cm.Parent().Name() == "inspr" {
 		return nil
 	}
 	cm.Root().SilenceErrors = true

--- a/cmd/inspr/cli/cli.go
+++ b/cmd/inspr/cli/cli.go
@@ -1,11 +1,11 @@
 package cli
 
 import (
+	"fmt"
 	"io"
-	"os"
 
 	"github.com/inspr/inspr/pkg/cmd"
-	cliutils "github.com/inspr/inspr/pkg/cmd/utils"
+	"github.com/inspr/inspr/pkg/cmd/utils"
 
 	"github.com/spf13/cobra"
 )
@@ -34,15 +34,15 @@ func NewInsprCommand(out, err io.Writer, version string) *cobra.Command {
 }
 
 func mainCmdPreRun(cm *cobra.Command, args []string) error {
-	cm.Root().SilenceUsage = true
-	// viper defaults values or reads from the config location
-	cliutils.InitViperConfig()
-
-	homeDir, _ := os.UserHomeDir()
-
-	if err := cliutils.ReadViperConfig(homeDir); err != nil {
-		return err
+	if cm.Name() == "init" {
+		return nil
 	}
-
-	return nil
+	cm.Root().SilenceUsage = true
+	utils.InitViperConfig()
+	// viper defaults values or reads from the config location
+	if cmd.InsprOptions.Config == "" {
+		fmt.Println("AAAAA")
+		return utils.ReadDefaultConfig()
+	}
+	return utils.ReadConfigFromFile(cmd.InsprOptions.Config)
 }

--- a/cmd/inspr/cli/cli.go
+++ b/cmd/inspr/cli/cli.go
@@ -21,6 +21,7 @@ func NewInsprCommand(out, err io.Writer, version string) *cobra.Command {
 			NewDescribeCmd(),
 			NewConfigChangeCmd(),
 			authCommand,
+			initCommand,
 		).
 		Version(version).
 		WithLongDescription("main command of the inspr cli, to see the full list of subcommands existent please use 'inspr help'").

--- a/cmd/inspr/cli/cli.go
+++ b/cmd/inspr/cli/cli.go
@@ -37,12 +37,18 @@ func mainCmdPreRun(cm *cobra.Command, args []string) error {
 	if cm.Name() == "init" {
 		return nil
 	}
+	cm.Root().SilenceErrors = true
 	cm.Root().SilenceUsage = true
 	utils.InitViperConfig()
 	// viper defaults values or reads from the config location
+	var err error
 	if cmd.InsprOptions.Config == "" {
-		fmt.Println("AAAAA")
-		return utils.ReadDefaultConfig()
+		err = utils.ReadDefaultConfig()
+	} else {
+		err = utils.ReadConfigFromFile(cmd.InsprOptions.Config)
 	}
-	return utils.ReadConfigFromFile(cmd.InsprOptions.Config)
+	if err != nil {
+		fmt.Fprintf(utils.GetCliOutput(), "Invalid config file! Did you run inspr init?")
+	}
+	return nil
 }

--- a/cmd/inspr/cli/cli_test.go
+++ b/cmd/inspr/cli/cli_test.go
@@ -2,10 +2,13 @@ package cli
 
 import (
 	"bytes"
+	"io/ioutil"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/inspr/inspr/pkg/cmd/utils"
+	"gopkg.in/yaml.v2"
 )
 
 // TestNewInsprCommand is mainly for improving test coverage,
@@ -31,6 +34,26 @@ func TestNewInsprCommand(t *testing.T) {
 	}
 }
 
+func prepareConfig(f string, c struct {
+	ServerIP string `yaml:"serverip"`
+	Scope    string `yaml:"scope"`
+}) {
+	os.Mkdir(filepath.Join(f, ".inspr"), 0755)
+	f = filepath.Join(f, ".inspr", "config")
+	arr, _ := yaml.Marshal(c)
+	ioutil.WriteFile(f, arr, 0644)
+}
+
+var defaultConfig struct {
+	ServerIP string `yaml:"serverip"`
+	Scope    string `yaml:"scope"`
+} = struct {
+	ServerIP string "yaml:\"serverip\""
+	Scope    string "yaml:\"scope\""
+}{
+	ServerIP: "http://localhost:8080",
+}
+
 func Test_mainCmdPreRun(t *testing.T) {
 	prepareToken(t)
 	folder := t.TempDir()
@@ -38,6 +61,8 @@ func Test_mainCmdPreRun(t *testing.T) {
 	os.Setenv("HOME", folder)
 	defer os.Setenv("HOME", prev)
 	utils.InitViperConfig()
+	prepareConfig(folder, defaultConfig)
+
 	type args struct {
 		args []string
 	}

--- a/cmd/inspr/cli/config_cmd.go
+++ b/cmd/inspr/cli/config_cmd.go
@@ -26,6 +26,7 @@ func NewConfigChangeCmd() *cobra.Command {
 func NewListConfig() *cobra.Command {
 	return cmd.NewCmd("list").
 		WithDescription("See the list of configuration variables and their current values").
+		WithCommonFlags().
 		WithExample("type", "config list").
 		NoArgs(doListConfig)
 }

--- a/cmd/inspr/cli/init.go
+++ b/cmd/inspr/cli/init.go
@@ -1,0 +1,72 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/inspr/inspr/pkg/cmd"
+	"github.com/inspr/inspr/pkg/ierrors"
+	"gopkg.in/yaml.v2"
+)
+
+type insprConfiguration struct {
+	ServerIP     string `yaml:"serverip"`
+	DefaultScope string `yaml:"scope"`
+}
+type initOptionsDT struct {
+	folder string
+}
+
+var initOptions initOptionsDT
+
+var initCommand = cmd.NewCmd("init").WithFlags(
+	&cmd.Flag{
+		Name:      "file",
+		Shorthand: "f",
+		DefValue:  "",
+		Usage:     "set the value for storing the configuration file",
+		Value:     &initOptions.folder,
+	},
+).NoArgs(
+	func(c context.Context) error {
+		config := insprConfiguration{}
+		fmt.Print("enter insprd host (http://localhost:8080):")
+		fmt.Scanln(&config.ServerIP)
+		if config.ServerIP == "" {
+			config.ServerIP = "http://localhost:8080"
+		}
+		fmt.Print("enter default scope (\"\"):")
+		fmt.Scanln(&config.DefaultScope)
+		var output *os.File
+		file := initOptions.folder
+
+		if file == "" {
+
+			defaultFolder, _ := os.UserHomeDir()
+			defaultFolder = filepath.Join(defaultFolder, ".inspr")
+			if f, err := os.Stat(defaultFolder); err != nil || !f.IsDir() {
+				if os.IsNotExist(err) {
+					os.Mkdir(defaultFolder, os.ModePerm)
+				} else if err != nil {
+					return ierrors.NewError().Message(err.Error()).Build()
+				} else {
+					return errors.New("default folder already defined as a file. did you name something .inspr in your home folder?")
+				}
+			}
+
+			output, _ = os.OpenFile(filepath.Join(defaultFolder, "config"), os.O_TRUNC|os.O_WRONLY|os.O_CREATE, 0644)
+		} else {
+			var err error
+			output, err = os.OpenFile(file, os.O_TRUNC|os.O_WRONLY|os.O_CREATE, 0644)
+			if err != nil {
+				return err
+			}
+		}
+
+		encoder := yaml.NewEncoder(output)
+		return encoder.Encode(config)
+	},
+)

--- a/cmd/inspr/cli/init.go
+++ b/cmd/inspr/cli/init.go
@@ -22,15 +22,17 @@ type initOptionsDT struct {
 
 var initOptions initOptionsDT
 
-var initCommand = cmd.NewCmd("init").WithFlags(
-	&cmd.Flag{
-		Name:      "file",
-		Shorthand: "f",
-		DefValue:  "",
-		Usage:     "set the value for storing the configuration file",
-		Value:     &initOptions.folder,
-	},
-).NoArgs(
+var initCommand = cmd.NewCmd("init").
+	WithDescription("Initialize the CLI configuration").
+	WithFlags(
+		&cmd.Flag{
+			Name:      "file",
+			Shorthand: "f",
+			DefValue:  "",
+			Usage:     "set the value for storing the configuration file",
+			Value:     &initOptions.folder,
+		},
+	).NoArgs(
 	func(c context.Context) error {
 		config := insprConfiguration{}
 		fmt.Print("enter insprd host (http://localhost:8080):")

--- a/cmd/uid_provider/inprov/cmd/create_user.go
+++ b/cmd/uid_provider/inprov/cmd/create_user.go
@@ -7,6 +7,7 @@ import (
 	"os"
 
 	"github.com/inspr/inspr/cmd/uid_provider/client"
+	"github.com/inspr/inspr/pkg/cmd"
 	build "github.com/inspr/inspr/pkg/cmd"
 	"gopkg.in/yaml.v2"
 )
@@ -34,35 +35,34 @@ var createUserCmd = build.NewCmd(
 ).WithExample(
 	"create a new user directly from a json file",
 	"inprov create --json user.json username password",
-).WithFlags([]*build.Flag{
-	{
+).WithFlags(
+	&cmd.Flag{
 		Name:      "username",
 		Shorthand: "u",
 		Usage:     "set the username of the user that will be created",
 		Value:     &createUsrOptions.username,
 		DefValue:  "",
 	},
-	{
+	&cmd.Flag{
 		Name:      "password",
 		Shorthand: "p",
 		Usage:     "set the password of the user that will be created",
 		Value:     &createUsrOptions.password,
 		DefValue:  "",
 	},
-	{
+	&cmd.Flag{
 		Name:     "yaml",
 		Usage:    "read the user definition from a YAML file",
 		Value:    &createUsrOptions.yaml,
 		DefValue: "",
 	},
-
-	{
+	&cmd.Flag{
 		Name:     "json",
 		Usage:    "read the user definition from a JSON file",
 		Value:    &createUsrOptions.json,
 		DefValue: "",
 	},
-}).ExactArgs(2, createUser)
+).ExactArgs(2, createUser)
 
 func createUser(ctx context.Context, inputArgs []string) error {
 	var err error

--- a/cmd/uid_provider/inprov/cmd/delete_usr.go
+++ b/cmd/uid_provider/inprov/cmd/delete_usr.go
@@ -17,14 +17,14 @@ var deleteUserCmd = build.NewCmd("delete").WithDescription(
 ).WithExample(
 	"delete a user given credentials",
 	"inprov delete --username userToBeDeleted username password",
-).WithFlags([]*build.Flag{
-	{
+).WithFlags(
+	&build.Flag{
 		Name:     "username",
 		Usage:    "username of the user to be deleted",
 		Value:    &deleteUsrOptions.username,
 		DefValue: "",
 	},
-}).ExactArgs(2, deleteAction)
+).ExactArgs(2, deleteAction)
 
 func deleteAction(ctx context.Context, inputArgs []string) error {
 

--- a/cmd/uid_provider/inprov/cmd/login.go
+++ b/cmd/uid_provider/inprov/cmd/login.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/inspr/inspr/cmd/uid_provider/client"
+	"github.com/inspr/inspr/pkg/cmd"
 	build "github.com/inspr/inspr/pkg/cmd"
 )
 
@@ -24,21 +25,21 @@ var loginCmd = build.NewCmd("login").WithDescription(
 ).WithExample(
 	"log in with your user and password",
 	"inprov login usr pwd",
-).WithFlags([]*build.Flag{
-	{
+).WithFlags(
+	&cmd.Flag{
 		Name:      "output",
 		Shorthand: "o",
 		Usage:     "set the output file for the returned token",
 		Value:     &loginOptions.output,
 		DefValue:  "",
 	},
-	{
+	&cmd.Flag{
 		Name:     "stdout",
 		Usage:    "set the output of the token to stdout",
 		Value:    &loginOptions.stdout,
 		DefValue: false,
 	},
-}).ExactArgs(2, loginAction)
+).ExactArgs(2, loginAction)
 
 func loginAction(c context.Context, s []string) error {
 

--- a/pkg/cmd/builder.go
+++ b/pkg/cmd/builder.go
@@ -17,7 +17,7 @@ type Builder interface {
 	WithLongDescription(long string) Builder
 	WithExample(comment, command string) Builder
 	WithFlagAdder(adder func(*pflag.FlagSet)) Builder
-	WithFlags([]*Flag) Builder
+	WithFlags(...*Flag) Builder
 	WithCommonFlags() Builder
 	Hidden() Builder
 	ExactArgs(argCount int, action func(context.Context, []string) error) *cobra.Command
@@ -89,6 +89,7 @@ func (b *builder) WithCommonFlags() Builder {
 // config.AddSetUnsetFlags(f)
 //
 // }).
+
 func (b *builder) WithFlagAdder(adder func(*pflag.FlagSet)) Builder {
 	adder(b.cmd.Flags())
 	return b
@@ -96,7 +97,7 @@ func (b *builder) WithFlagAdder(adder func(*pflag.FlagSet)) Builder {
 
 // WithFlags - receives a slice of flags (defined in the cmd pkg)
 // adds each of the flags in the command
-func (b *builder) WithFlags(flags []*Flag) Builder {
+func (b *builder) WithFlags(flags ...*Flag) Builder {
 	for _, f := range flags {
 		fl := f.Flag()
 		b.cmd.Flags().AddFlag(fl)

--- a/pkg/cmd/builder_test.go
+++ b/pkg/cmd/builder_test.go
@@ -331,7 +331,7 @@ func Test_builder_WithFlagAdder(t *testing.T) {
 			}
 			_ = b.WithFlagAdder(tt.args.adder)
 
-			if !reflect.DeepEqual(bufResp.String(), tt.want) {
+			if !reflect.DeepEqual(len(bufResp.String()), len(tt.want)) {
 				t.Errorf(
 					"builder.WithFlagAdder() = %v, want %v",
 					bufResp,
@@ -396,7 +396,7 @@ func Test_builder_WithFlags(t *testing.T) {
 				)
 			}
 
-			got = b.WithFlags(tt.args.flags).NoArgs(nil)
+			got = b.WithFlags(tt.args.flags...).NoArgs(nil)
 			if got.Flags() == nil {
 				t.Errorf(
 					"builder.WithFlags() = %v, want not nil",

--- a/pkg/cmd/constants.go
+++ b/pkg/cmd/constants.go
@@ -15,4 +15,6 @@ var InsprOptions struct {
 	Update bool
 
 	Token string
+
+	Config string
 }

--- a/pkg/cmd/flags.go
+++ b/pkg/cmd/flags.go
@@ -64,7 +64,7 @@ var flagRegistry = []Flag{
 	{
 		Name:      "config",
 		Shorthand: "c",
-		Usage:     "set the config folder for the command",
+		Usage:     "set the config file for the command",
 		Value:     &InsprOptions.Config,
 		DefValue:  "",
 		DefinedOn: []string{"all"},

--- a/pkg/cmd/flags.go
+++ b/pkg/cmd/flags.go
@@ -61,6 +61,14 @@ var flagRegistry = []Flag{
 		DefValue:  "",
 		DefinedOn: []string{"all"},
 	},
+	{
+		Name:      "config",
+		Shorthand: "c",
+		Usage:     "set the config folder for the command",
+		Value:     &InsprOptions.Config,
+		DefValue:  "",
+		DefinedOn: []string{"all"},
+	},
 }
 
 func methodNameByType(v reflect.Value) string {

--- a/pkg/cmd/utils/cli_client.go
+++ b/pkg/cmd/utils/cli_client.go
@@ -75,7 +75,7 @@ func RequestErrorMessage(err error, w io.Writer) {
 	if ok {
 		switch ierr.Code {
 		case ierrors.Unauthorized:
-			fmt.Fprintf(w, "did you login ?\n")
+			fmt.Fprintf(w, "We couldn't authenticate with the cluster. Is your token configured correctly?\n")
 		case ierrors.Forbidden:
 			fmt.Fprintf(w, "forbidden operation, please check for the scope.\n")
 		default:

--- a/pkg/cmd/utils/cli_client_test.go
+++ b/pkg/cmd/utils/cli_client_test.go
@@ -201,7 +201,7 @@ func TestRequestErrorMessage(t *testing.T) {
 			args: args{
 				ierrors.NewError().Unauthorized().Build(),
 			},
-			wantW: "did you login ?\n",
+			wantW: "We couldn't authenticate with the cluster. Is your token configured correctly?\n",
 		},
 		{
 			name: "ierror-forbidden",

--- a/pkg/rest/request/request.go
+++ b/pkg/rest/request/request.go
@@ -51,7 +51,7 @@ func (c Client) Send(ctx context.Context, route string, method string, body inte
 		if err != nil {
 			return ierrors.
 				NewError().
-				BadRequest().
+				Unauthorized().
 				Message("unable to get token from configuration").
 				InnerError(err).
 				Build()


### PR DESCRIPTION
# Description

Kind: feature
<!-- Specify the kind of the pull request, as in if it's a Bug fix, a Feature, a Story, a Tech Pendency, etc.
-->

Section: cli
<!-- Section can be the specific folder or file refered by the pull request, like "pkg/ierrors", or a most wide section that comprehends multiple folders and files, like "Sidecar".
-->

Summary: creates the init command for config initialization
<!-- A quick description of what was changed, fixed or implemented (e.g. "Configured all Insprd routes to validate authentication")
-->

## Changelog

- feat:
    - creates an init command for configuration initialization
    - adds config flag to specify configuration file
    - changes flow so that if the config is invalid, asks for initialization
- ref:
    - refactors configuration initialization to allow different files
    - changes command builder to now use variadic flag argument instead of slice
- fix:
    - silences main command to remove duplicate errors

Closes #15 
