### PR TITLE
Fix: CORE-310 | Automatic Helm chart tags update

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,11 +35,10 @@ jobs:
 
       - name: Run Skaffold build
         uses: hiberbee/github-action-skaffold@latest
-        # with:
-        #   cache-artifacts: false
-        #   filename: /home/runner/work/inspr/inspr/skaffold.yaml
-        #   command: build --file-output=tags.out
-        run: echo $PWD
+        with:
+          cache-artifacts: false
+          filename: /home/runner/work/inspr/inspr/skaffold.yaml
+          command: build --file-output=tags.out
 
       - name: Helm Chart update
         run: bash .github/scripts/update_tags.sh https://inspr-charts.storage.googleapis.com/ gs://inspr-charts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
       - uses: yokawasa/action-setup-kube-tools@v0.7.1
         with:
           skaffold: "1.21.0"
+          helmv3: "3.5.4"
       - uses: actions/setup-go@v2
         with:
           go-version: "^1.16.0"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
           PROJECT_ID: red-inspr
           APPLICATION_CREDENTIALS: ${{ secrets.GCR_ACCOUNT_KEY }}
         with:
-          args: auth configure-docker
+          args: gcloud auth activate-service-account --key-file=${{ secrets.GCR_ACCOUNT_KEY }}
 
       # - name: Build CLI
       #   run: bash .github/scripts/buildcli.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,8 +37,7 @@ jobs:
         uses: hiberbee/github-action-skaffold@latest
         with:
           cache-artifacts: false
-          filename: ../skaffold.yaml
-          command: build --file-output=tags.out
+          command: build --file-output=tags.out --filename=../skaffold.yaml
 
       - name: Helm Chart update
         run: bash .github/scripts/update_tags.sh https://inspr-charts.storage.googleapis.com/ gs://inspr-charts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,9 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 2
+      - uses: yokawasa/action-setup-kube-tools@v0.7.1
+        with:
+          skaffold: "1.21.0"
       - uses: actions/setup-go@v2
         with:
           go-version: "^1.16.0"
@@ -32,11 +35,6 @@ jobs:
       - name: Create temp file to store skaffold build return
         run: |
           touch tags.out
-
-      - name: Install skaffold
-        uses: daisaru11/setup-cd-tools@v1
-        with:
-          skaffold: "1.21.0"
 
       - name: Run skaffold build
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,25 +32,26 @@ jobs:
         with:
           go-version: "^1.16.0"
 
-      # - name: Set up Cloud SDK
-      #   uses: google-github-actions/setup-gcloud@master
-      #   with:
-      #     project_id: ${{ secrets.GCP_PROJECT_ID }}
-      #     service_account_key: ${{ secrets.GCP_SA_KEY }}
-      #     export_default_credentials: true
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@master
+        with:
+          project_id: red-inspr
+          export_default_credentials: true
+          # service_account_key: ${{ secrets.GCP_SA_KEY }}
+
       - name: Create file with GCR stuff
         run: 'echo "$GCR_KEY" > $GCR_FILENAME.json'
         shell: bash
         env:
           GCR_KEY: ${{ secrets.GCR_ACCOUNT_KEY }}
 
-      - name: Activate GCR account
-        uses: actions-hub/gcloud@master
-        env:
-          PROJECT_ID: "red-inspr"
-          APPLICATION_CREDENTIALS: ${{ secrets.GCR_ACCOUNT_KEY }}
-        with:
-          args: auth activate-service-account ${{ secrets.GCR_ACCOUNT }} --key-file=$GCR_FILENAME.json
+      # - name: Activate GCR account
+      #   uses: actions-hub/gcloud@master
+      #   env:
+      #     PROJECT_ID: "red-inspr"
+      #     APPLICATION_CREDENTIALS: ${{ secrets.GCR_ACCOUNT_KEY }}
+      #   with:
+      #     args: auth activate-service-account ${{ secrets.GCR_ACCOUNT }} --key-file=$GCR_FILENAME.json
 
       # - name: Switch to active GCR account
       #   uses: actions-hub/gcloud@master
@@ -61,6 +62,10 @@ jobs:
 
       # - name: Build CLI
       #   run: bash .github/scripts/buildcli.sh
+
+      - name: Configure GCR service account
+        run: |
+          gcloud auth activate-service-account ${{ secrets.GCR_ACCOUNT }} --key-file=$GCR_FILENAME.json
 
       - name: Create temp file to store skaffold build return
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,11 +29,12 @@ jobs:
         with:
           go-version: "^1.16.0"
 
-      - name: Echo data
-        run: |
-          for file in /home/runner/work/inspr/inspr/*; do
-            echo "${file##*/}"
-          done
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@master
+        with:
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+          service_account_key: ${{ secrets.GCP_SA_KEY }}
+          export_default_credentials: true
 
       # - name: Build CLI
       #   run: bash .github/scripts/buildcli.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,11 +33,20 @@ jobs:
         run: |
           touch tags.out
 
-      - name: Run Skaffold build
-        uses: hiberbee/github-action-skaffold@latest
+      - name: Install skaffold
+        uses: daisaru11/setup-cd-tools@v1
         with:
-          cache-artifacts: false
-          command: build --file-output=tags.out --filename=/home/runner/work/inspr/inspr/skaffold.yaml
+          skaffold: "1.21.0"
+
+      - name: Run skaffold build
+        run: |
+          skaffold build --file-output=tags.out --filename=/home/runner/work/inspr/inspr/skaffold.yaml
+
+      # - name: Run Skaffold build
+      #   uses: hiberbee/github-action-skaffold@latest
+      #   with:
+      #     cache-artifacts: false
+      #     command: build --file-output=tags.out --filename=/home/runner/work/inspr/inspr/skaffold.yaml
 
       - name: Helm Chart update
         run: bash .github/scripts/update_tags.sh https://inspr-charts.storage.googleapis.com/ gs://inspr-charts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
         uses: hiberbee/github-action-skaffold@latest
         with:
           cache-artifacts: false
-          command: build --file-output=tags.out --filename=../../skaffold.yaml
+          command: build --file-output=tags.out --filename=/home/runner/work/inspr/inspr/skaffold.yaml
 
       - name: Helm Chart update
         run: bash .github/scripts/update_tags.sh https://inspr-charts.storage.googleapis.com/ gs://inspr-charts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,10 +38,10 @@ jobs:
 
       - uses: actions-hub/gcloud@master
         env:
-          PROJECT_ID: red-inspr
+          PROJECT_ID: "red-inspr"
           APPLICATION_CREDENTIALS: ${{ secrets.GCR_ACCOUNT_KEY }}
         with:
-          args: gcloud auth activate-service-account --key-file=${{ secrets.GCR_ACCOUNT_KEY }}
+          args: auth activate-service-account --key-file=${{ secrets.GCR_ACCOUNT_KEY }}
 
       # - name: Build CLI
       #   run: bash .github/scripts/buildcli.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
           PROJECT_ID: "red-inspr"
           APPLICATION_CREDENTIALS: ${{ secrets.GCR_ACCOUNT_KEY }}
         with:
-          args: auth activate-service-account --key-file=$GCR_FILENAME.json
+          args: auth activate-service-account ${{ secrets.GCR_ACCOUNT }}--key-file=$GCR_FILENAME.json
 
       # - name: Build CLI
       #   run: bash .github/scripts/buildcli.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,16 +36,12 @@ jobs:
       #     service_account_key: ${{ secrets.GCP_SA_KEY }}
       #     export_default_credentials: true
 
-      - name: Get GCR config
-        run: |
-          echo ${{ secrets.GCR_ACCOUNT_KEY }} > "${{ github.sha }}".json
-
       - uses: actions-hub/gcloud@master
         env:
           PROJECT_ID: red-inspr
           APPLICATION_CREDENTIALS: ${{ secrets.GCR_ACCOUNT_KEY }}
         with:
-          args: auth activate-service-account --key-file="${{ github.sha }}".json
+          args: auth configure-docker
 
       # - name: Build CLI
       #   run: bash .github/scripts/buildcli.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Run Skaffold build
         uses: hiberbee/github-action-skaffold@latest
         with:
-          command: build --file-output=tags.out --cache-artifacts=false
+          command: build --file-output=tags.out --filename=/home/runner/work/inspr/inspr/skaffold.yaml
 
       - name: Helm Chart update
         run: bash .github/scripts/update_tags.sh https://inspr-charts.storage.googleapis.com/ gs://inspr-charts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
           PROJECT_ID: "red-inspr"
           APPLICATION_CREDENTIALS: ${{ secrets.GCR_ACCOUNT_KEY }}
         with:
-          args: auth activate-service-account ${{ secrets.GCR_ACCOUNT }}--key-file=$GCR_FILENAME.json
+          args: auth activate-service-account ${{ secrets.GCR_ACCOUNT }} --key-file=$GCR_FILENAME.json
 
       # - name: Build CLI
       #   run: bash .github/scripts/buildcli.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,9 @@ jobs:
         env:
           GCR_KEY: ${{ secrets.GCR_ACCOUNT_KEY }}
 
+      - env:
+          GOOGLE_APPLICATION_CREDENTIALS: $GCR_FILENAME.json
+
       - name: Activate GCR account
         uses: actions-hub/gcloud@master
         env:
@@ -52,12 +55,12 @@ jobs:
         with:
           args: auth activate-service-account ${{ secrets.GCR_ACCOUNT }} --key-file=$GCR_FILENAME.json
 
-      - name: Switch to active GCR account
-        uses: actions-hub/gcloud@master
-        env:
-          PROJECT_ID: "red-inspr"
-        with:
-          args: config set account ${{ secrets.GCR_ACCOUNT }}
+      # - name: Switch to active GCR account
+      #   uses: actions-hub/gcloud@master
+      #   env:
+      #     PROJECT_ID: "red-inspr"
+      #   with:
+      #     args: config set account ${{ secrets.GCR_ACCOUNT }}
 
       # - name: Build CLI
       #   run: bash .github/scripts/buildcli.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
         uses: hiberbee/github-action-skaffold@latest
         with:
           cache-artifacts: false
-          filename: /home/runner/work/inspr/inspr/skaffold.yaml
+          filename: ../skaffold.yaml
           command: build --file-output=tags.out
 
       - name: Helm Chart update

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,13 +22,12 @@ jobs:
 
       - name: Echo data
         run: |
-          ls
           for file in /home/runner/work/inspr/inspr/*; do
             echo "${file##*/}"
           done
 
-      - name: Build CLI
-        run: bash .github/scripts/buildcli.sh
+      # - name: Build CLI
+      #   run: bash .github/scripts/buildcli.sh
 
       - name: Create temp file to store skaffold build return
         run: |
@@ -37,7 +36,10 @@ jobs:
       - name: Run Skaffold build
         uses: hiberbee/github-action-skaffold@latest
         with:
-          command: build --file-output=tags.out --filename=/home/runner/work/inspr/inspr/skaffold.yaml
+          cache-artifacts: false
+          filename: /home/runner/work/inspr/inspr/skaffold.yaml
+          command: build --file-output=tags.out
+        run: echo $PWD
 
       - name: Helm Chart update
         run: bash .github/scripts/update_tags.sh https://inspr-charts.storage.googleapis.com/ gs://inspr-charts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,9 +44,6 @@ jobs:
         env:
           GCR_KEY: ${{ secrets.GCR_ACCOUNT_KEY }}
 
-      - env:
-          GOOGLE_APPLICATION_CREDENTIALS: $GCR_FILENAME.json
-
       - name: Activate GCR account
         uses: actions-hub/gcloud@master
         env:
@@ -70,6 +67,8 @@ jobs:
           touch tags.out
 
       - name: Run skaffold build
+        env:
+          GOOGLE_APPLICATION_CREDENTIALS: $GCR_FILENAME.json
         run: |
           skaffold build --file-output=tags.out --filename=/home/runner/work/inspr/inspr/skaffold.yaml
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,12 +36,16 @@ jobs:
       #     service_account_key: ${{ secrets.GCP_SA_KEY }}
       #     export_default_credentials: true
 
+      - name: Get GCR config
+        run: |
+          echo ${{ secrets.GCR_ACCOUNT_KEY }}> "${{ github.sha }}".json
+
       - uses: actions-hub/gcloud@master
         env:
           PROJECT_ID: red-inspr
           APPLICATION_CREDENTIALS: ${{ secrets.GCR_ACCOUNT_KEY }}
         with:
-          args: auth activate-service-account
+          args: auth activate-service-account --key-file="${{ github.sha }}".json
 
       # - name: Build CLI
       #   run: bash .github/scripts/buildcli.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,12 +29,19 @@ jobs:
         with:
           go-version: "^1.16.0"
 
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@master
+      # - name: Set up Cloud SDK
+      #   uses: google-github-actions/setup-gcloud@master
+      #   with:
+      #     project_id: ${{ secrets.GCP_PROJECT_ID }}
+      #     service_account_key: ${{ secrets.GCP_SA_KEY }}
+      #     export_default_credentials: true
+
+      - uses: actions-hub/gcloud@master
+        env:
+          PROJECT_ID: red-inspr
+          APPLICATION_CREDENTIALS: ${{ secrets.GCR_ACCOUNT_KEY }}
         with:
-          project_id: ${{ secrets.GCP_PROJECT_ID }}
-          service_account_key: ${{ secrets.GCP_SA_KEY }}
-          export_default_credentials: true
+          args: auth activate-service-account
 
       # - name: Build CLI
       #   run: bash .github/scripts/buildcli.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
         uses: hiberbee/github-action-skaffold@latest
         with:
           cache-artifacts: false
-          command: build --file-output=tags.out --filename=../skaffold.yaml
+          command: build --file-output=tags.out --filename=../../skaffold.yaml
 
       - name: Helm Chart update
         run: bash .github/scripts/update_tags.sh https://inspr-charts.storage.googleapis.com/ gs://inspr-charts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,11 @@
 name: "tagged-release"
 
 on:
-  push
-  # branches:
-  #   - develop
-  # tags:
-  #   - "v*"
+  push:
+    branches:
+      - develop
+    tags:
+      - "v*"
 
 env:
   GCR_FILENAME: "${{ github.sha }}"
@@ -37,7 +37,6 @@ jobs:
         with:
           project_id: red-inspr
           export_default_credentials: true
-          # service_account_key: ${{ secrets.GCP_SA_KEY }}
 
       - name: Create file with GCR stuff
         run: 'echo "$GCR_KEY" > $GCR_FILENAME.json'
@@ -45,23 +44,8 @@ jobs:
         env:
           GCR_KEY: ${{ secrets.GCR_ACCOUNT_KEY }}
 
-      # - name: Activate GCR account
-      #   uses: actions-hub/gcloud@master
-      #   env:
-      #     PROJECT_ID: "red-inspr"
-      #     APPLICATION_CREDENTIALS: ${{ secrets.GCR_ACCOUNT_KEY }}
-      #   with:
-      #     args: auth activate-service-account ${{ secrets.GCR_ACCOUNT }} --key-file=$GCR_FILENAME.json
-
-      # - name: Switch to active GCR account
-      #   uses: actions-hub/gcloud@master
-      #   env:
-      #     PROJECT_ID: "red-inspr"
-      #   with:
-      #     args: config set account ${{ secrets.GCR_ACCOUNT }}
-
-      # - name: Build CLI
-      #   run: bash .github/scripts/buildcli.sh
+      - name: Build CLI
+        run: bash .github/scripts/buildcli.sh
 
       - name: Configure GCR service account
         run: |
@@ -76,12 +60,6 @@ jobs:
           GOOGLE_APPLICATION_CREDENTIALS: $GCR_FILENAME.json
         run: |
           skaffold build --file-output=tags.out --filename=/home/runner/work/inspr/inspr/skaffold.yaml
-
-      # - name: Run Skaffold build
-      #   uses: hiberbee/github-action-skaffold@latest
-      #   with:
-      #     cache-artifacts: false
-      #     command: build --file-output=tags.out --filename=/home/runner/work/inspr/inspr/skaffold.yaml
 
       - name: Helm Chart update
         run: bash .github/scripts/update_tags.sh https://inspr-charts.storage.googleapis.com/ gs://inspr-charts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,12 +44,20 @@ jobs:
         env:
           GCR_KEY: ${{ secrets.GCR_ACCOUNT_KEY }}
 
-      - uses: actions-hub/gcloud@master
+      - name: Activate GCR account
+        uses: actions-hub/gcloud@master
         env:
           PROJECT_ID: "red-inspr"
           APPLICATION_CREDENTIALS: ${{ secrets.GCR_ACCOUNT_KEY }}
         with:
           args: auth activate-service-account ${{ secrets.GCR_ACCOUNT }} --key-file=$GCR_FILENAME.json
+
+      - name: Switch to active GCR account
+        uses: actions-hub/gcloud@master
+        env:
+          PROJECT_ID: "red-inspr"
+        with:
+          args: config set account ${{ secrets.GCR_ACCOUNT }}
 
       # - name: Build CLI
       #   run: bash .github/scripts/buildcli.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,9 @@ on:
   # tags:
   #   - "v*"
 
+env:
+  GCR_FILENAME: "${{ github.sha }}"
+
 jobs:
   tagged-release:
     name: "Tagged Release"
@@ -35,13 +38,18 @@ jobs:
       #     project_id: ${{ secrets.GCP_PROJECT_ID }}
       #     service_account_key: ${{ secrets.GCP_SA_KEY }}
       #     export_default_credentials: true
+      - name: Create file with GCR stuff
+        run: 'echo "$GCR_KEY" > $GCR_FILENAME.json'
+        shell: bash
+        env:
+          GCR_KEY: ${{ secrets.GCR_ACCOUNT_KEY }}
 
       - uses: actions-hub/gcloud@master
         env:
           PROJECT_ID: "red-inspr"
           APPLICATION_CREDENTIALS: ${{ secrets.GCR_ACCOUNT_KEY }}
         with:
-          args: auth activate-service-account --key-file=${{ secrets.GCR_ACCOUNT_KEY }}
+          args: auth activate-service-account --key-file=$GCR_FILENAME.json
 
       # - name: Build CLI
       #   run: bash .github/scripts/buildcli.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,11 +1,11 @@
 name: "tagged-release"
 
 on:
-  push:
-    branches:
-      - develop
-    tags:
-      - "v*"
+  push
+  # branches:
+  #   - develop
+  # tags:
+  #   - "v*"
 
 jobs:
   tagged-release:
@@ -20,6 +20,13 @@ jobs:
         with:
           go-version: "^1.16.0"
 
+      - name: Echo data
+        run: |
+          ls
+          for file in /home/runner/work/inspr/inspr/*; do
+            echo "${file##*/}"
+          done
+
       - name: Build CLI
         run: bash .github/scripts/buildcli.sh
 
@@ -30,7 +37,7 @@ jobs:
       - name: Run Skaffold build
         uses: hiberbee/github-action-skaffold@latest
         with:
-          command: build --cache-artifacts=false --file-output=tags.out
+          command: build --file-output=tags.out --cache-artifacts=false
 
       - name: Helm Chart update
         run: bash .github/scripts/update_tags.sh https://inspr-charts.storage.googleapis.com/ gs://inspr-charts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,8 +18,13 @@ jobs:
           fetch-depth: 2
       - uses: yokawasa/action-setup-kube-tools@v0.7.1
         with:
-          skaffold: "1.21.0"
+          setup-tools: |
+            kubectl
+            helmv3
+            skaffold
+          kubectl: "1.20.2"
           helmv3: "3.5.4"
+          skaffold: "1.21.0"
       - uses: actions/setup-go@v2
         with:
           go-version: "^1.16.0"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,10 +35,10 @@ jobs:
 
       - name: Run Skaffold build
         uses: hiberbee/github-action-skaffold@latest
-        with:
-          cache-artifacts: false
-          filename: /home/runner/work/inspr/inspr/skaffold.yaml
-          command: build --file-output=tags.out
+        # with:
+        #   cache-artifacts: false
+        #   filename: /home/runner/work/inspr/inspr/skaffold.yaml
+        #   command: build --file-output=tags.out
         run: echo $PWD
 
       - name: Helm Chart update

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Get GCR config
         run: |
-          echo ${{ secrets.GCR_ACCOUNT_KEY }}> "${{ github.sha }}".json
+          echo ${{ secrets.GCR_ACCOUNT_KEY }} > "${{ github.sha }}".json
 
       - uses: actions-hub/gcloud@master
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,14 @@
 
 # Changelog
 
-### #56 Story CORE-417 | Create a broker-tracking structure
+### #59 - Fix: CORE-310 | Automatic Helm chart tags update
+- fixes:
+    - The workflow/GitHub action `release.yml` wasn't properly working. To fix it:
+        - Added action to setup Skaffold and Helm tools
+        - Added action to setup Cloud SDK and configure the service account
+---
+
+### #56 - Story CORE-417 | Create a broker-tracking structure
 - features:
     - created a Brokers struct on meta/brokers to store broker information.
     - created a Brokers interface to handle storage of broker data


### PR DESCRIPTION
# Description

Kind: Fix
<!-- Specify the kind of the pull request, as in if it's a Bug fix, a Feature, a Story, a Tech Pendency, etc.
-->

Section: DevOps
<!-- Section can be the specific folder or file refered by the pull request, like "pkg/ierrors", or a most wide section that comprehends multiple folders and files, like "Sidecar".
-->

Summary: Fixed the new tagged-release GitHub action so it properly builds Inspr CLI, updates the Helm Chart and automatically creates a new release on GitHub.
<!-- A quick description of what was changed, fixed or implemented (e.g. "Configured all Insprd routes to validate authentication")
-->

## Changelog

> The structure of the `release.yml` workflow wasn't working properly, so it's now fixed

## Pay attention to

> Again, I'm still getting used to GitHub actions, so any suggestions are welcome
