### PR TITLE
Bugfix CORE-431 | UIDP Refresh token crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,21 @@
 
 # Changelog
 
+### #68 Bugfix CORE-431 | UIDP Refresh token crash
+- refactors:
+    - Improved some error's messages, most of them in `cmd/authsvc`
+    - Changed some logs so they use `zap.logger` instead of `log` and improved their messages
+    - Fixed misspelings pointed out by Go Report
+    - Changed "POST", "GET", "DELETE" and "PUT" to use `net/http` constants instead
+    - Renamed the embed file used in `examples/controller`
+---
+
 ### #67 Tech CORE-429 | Change the inspr cmd cluster command to ignore the .inspr/token
 - features:
     - Updated the Init function in the auth package so now it creates .inspr/token if it doesn't exist
     - Added the admin permissions in auth models
     - The admin user is now initialized with the admin permissions created in auth models
+---
 
 ### #63 Story CORE-414 | Adapt the current sidecar to a load balancer sidecar
 - features:

--- a/build/uidp_helm/values.yaml
+++ b/build/uidp_helm/values.yaml
@@ -41,7 +41,7 @@ secretRepository: gcr.io/red-inspr/uidp/redis/secret
 secret:
   privateKeyName: redisprivatekey
   adminPassword: "123456"
-  adminToken: eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2MjIxNTg1ODQsInBheWxvYWQiOnsidWlkIjoiIiwicGVybWlzc2lvbnMiOnsiIjpbImNyZWF0ZTp0b2tlbiJdfSwicmVmcmVzaCI6bnVsbCwicmVmcmVzaHVybCI6IiJ9fQ.HRre34TDJgj6PmdS8-eNPIgz1T6MOU76KWL7rjCyYF0XOVa_zmxM1_FvqijBH3jWH5cw0LTATJz803HXcOeB3Q
+  adminToken: eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2MjIyMTEyOTgsInBheWxvYWQiOnsidWlkIjoiIiwicGVybWlzc2lvbnMiOnsiIjpbImNyZWF0ZTp0b2tlbiJdfSwicmVmcmVzaCI6bnVsbCwicmVmcmVzaHVybCI6IiJ9fQ.fBw__G1U_fw9A-lckqVwlxDyyj6YxHme-QUSDhvSeGLP5iFy_qiSDMgf9d_Wz547OICw-mawwzJGTMljpzQRcQ
   # set this admin token from a token that contains full power over the cluster
 
 statefulset:

--- a/build/uidp_helm/values.yaml
+++ b/build/uidp_helm/values.yaml
@@ -41,8 +41,8 @@ secretRepository: gcr.io/red-inspr/uidp/redis/secret
 secret:
   privateKeyName: redisprivatekey
   adminPassword: "123456"
-  adminToken: eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2MjE0NDk3MjcsInBheWxvYWQiOnsidWlkIjoiIiwicGVybWlzc2lvbnMiOnsiIjpbImNyZWF0ZTp0b2tlbiJdfSwicmVmcmVzaCI6bnVsbCwicmVmcmVzaHVybCI6IiJ9fQ.bj6_uTBQMFoJL3nPCmPhzvsMY0NGkKQjSZl2MKHoYRsBVvsM0_NZpXQjt_YxQtdtrQF_x3zMyjgxcikrItmEnQ
- # set this admin token from a token that contains full power over the cluster
+  adminToken: eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2MjIxNTg1ODQsInBheWxvYWQiOnsidWlkIjoiIiwicGVybWlzc2lvbnMiOnsiIjpbImNyZWF0ZTp0b2tlbiJdfSwicmVmcmVzaCI6bnVsbCwicmVmcmVzaHVybCI6IiJ9fQ.HRre34TDJgj6PmdS8-eNPIgz1T6MOU76KWL7rjCyYF0XOVa_zmxM1_FvqijBH3jWH5cw0LTATJz803HXcOeB3Q
+  # set this admin token from a token that contains full power over the cluster
 
 statefulset:
   uidpName: uidp-stset
@@ -65,7 +65,7 @@ deployment:
 
 ingress:
   name: uidp-ingress
-  host: "inspr.com"
+  host: inspr.com
 
 redis:
   password: ""

--- a/cmd/authsvc/api/controllers/base.go
+++ b/cmd/authsvc/api/controllers/base.go
@@ -23,7 +23,7 @@ type Server struct {
 // Init - configures the server
 func (s *Server) Init() {
 	var err error
-	s.logger, _ = zap.NewDevelopment(zap.Fields(zap.String("section", "auth-provider")))
+	s.logger, _ = zap.NewProduction(zap.Fields(zap.String("section", "auth-provider")))
 
 	keyPem, ok := os.LookupEnv("JWT_PRIVATE_KEY")
 	if !ok {

--- a/cmd/authsvc/api/controllers/init.go
+++ b/cmd/authsvc/api/controllers/init.go
@@ -2,7 +2,6 @@ package controllers
 
 import (
 	"encoding/json"
-	"log"
 	"net/http"
 	"os"
 	"time"
@@ -10,6 +9,7 @@ import (
 	"github.com/inspr/inspr/pkg/auth"
 	"github.com/inspr/inspr/pkg/ierrors"
 	"github.com/inspr/inspr/pkg/rest"
+	"go.uber.org/zap"
 )
 
 var initialized bool
@@ -21,17 +21,22 @@ func (server *Server) HandleInit() rest.Handler {
 			Key string
 			auth.Payload
 		}
+
 		decoder := json.NewDecoder(r.Body)
 		decoder.Decode(&data)
 		if initialized {
 			rest.ERROR(w, ierrors.NewError().Message("already initialized").Build())
 			return
 		}
-		log.Printf("data = %+v\n", data)
+
+		server.logger.Debug("received data to initialize auth service",
+			zap.Any("data: ", data))
+
 		if data.Key != os.Getenv("INSPR_INIT_KEY") {
 			rest.ERROR(w, ierrors.NewError().Message("invalid key").Forbidden().Build())
 			return
 		}
+
 		initialized = true
 		token, err := server.tokenize(data.Payload, time.Now().Add(time.Minute*30))
 		if err != nil {

--- a/cmd/authsvc/api/controllers/refresh.go
+++ b/cmd/authsvc/api/controllers/refresh.go
@@ -20,7 +20,6 @@ func (server *Server) Refresh() rest.Handler {
 	return func(w http.ResponseWriter, r *http.Request) {
 		headerContent := r.Header["Authorization"]
 
-		server.logger.Debug("headerContent:", zap.Any("content", headerContent))
 		if len(headerContent) != 1 ||
 			!strings.HasPrefix(headerContent[0], "Bearer ") {
 			err := ierrors.NewError().Unauthorized().Message("bad Request, expected: Authorization: Bearer <token>").Build()
@@ -29,7 +28,6 @@ func (server *Server) Refresh() rest.Handler {
 		}
 
 		token := []byte(strings.TrimPrefix(headerContent[0], "Bearer "))
-		server.logger.Debug("bearer token", zap.String("value", string(token)))
 
 		server.logger.Info("parsing received bearer token")
 		_, err := jwt.Parse(

--- a/cmd/authsvc/api/controllers/refresh.go
+++ b/cmd/authsvc/api/controllers/refresh.go
@@ -3,7 +3,6 @@ package controllers
 import (
 	"bytes"
 	"encoding/json"
-	"log"
 	"net/http"
 	"strings"
 	"time"
@@ -13,6 +12,7 @@ import (
 	"github.com/inspr/inspr/pkg/rest"
 	"github.com/lestrrat-go/jwx/jwa"
 	"github.com/lestrrat-go/jwx/jwt"
+	"go.uber.org/zap"
 )
 
 // Refresh returns the refreshing endpoint. This entpoint receives a refresh token and a refresh url, it returns a refreshed token.
@@ -20,7 +20,7 @@ func (server *Server) Refresh() rest.Handler {
 	return func(w http.ResponseWriter, r *http.Request) {
 		headerContent := r.Header["Authorization"]
 
-		log.Printf("headerContent = %+v\n", headerContent)
+		server.logger.Info("headerContent:", zap.Any("content", headerContent))
 		if len(headerContent) != 1 ||
 			!strings.HasPrefix(headerContent[0], "Bearer ") {
 			err := ierrors.NewError().Unauthorized().Message("bad Request, expected: Authorization: Bearer <token>").Build()
@@ -29,42 +29,55 @@ func (server *Server) Refresh() rest.Handler {
 		}
 
 		token := []byte(strings.TrimPrefix(headerContent[0], "Bearer "))
-		log.Printf("string(token) = %+v\n", string(token))
+		server.logger.Info("bearer token", zap.String("value", string(token)))
 
+		server.logger.Debug("parsing received bearer token")
 		_, err := jwt.Parse(
 			token,
 			jwt.WithValidate(true),
 			jwt.WithVerify(jwa.RS256, server.privKey.PublicKey),
 		)
 		if err != nil && err.Error() != `exp not satisfied` {
-			err := ierrors.NewError().Forbidden().Message("invalid token").Build()
+			err := ierrors.NewError().Forbidden().
+				Message("couldn't parse token: %v", err).Build()
+
 			rest.ERROR(w, err)
 			return
 		}
 
+		server.logger.Debug("deserializing parsed token")
 		load, err := auth.Desserialize(token)
 		if err != nil {
-			err := ierrors.NewError().Forbidden().Message("invalid token, error: %s", err.Error()).Build()
+			err := ierrors.NewError().Forbidden().
+				Message("couldn't desserialize token: %v", err).Build()
+
 			rest.ERROR(w, err)
 			return
 		}
-		log.Printf("load = %+v\n", load)
 
+		server.logger.Info("received payload", zap.Any("content", load))
+
+		server.logger.Debug("refreshing old payload")
 		payload, err := refreshPayload(load.Refresh, load.RefreshURL)
 		if err != nil {
-			err := ierrors.NewError().InternalServer().Message("invalid token").Build()
+			err := ierrors.NewError().InternalServer().
+				Message("couldn't refresh payload: %v", err).Build()
+
 			rest.ERROR(w, err)
 			return
 		}
-		log.Printf("payload = %+v\n", payload)
 
-		signed, err := server.tokenize(*payload, time.Now().Add(time.Hour*24))
+		server.logger.Info("refreshed payload", zap.Any("content", payload))
+
+		signed, err := server.tokenize(*payload, time.Now().Add(time.Minute*8))
 		if err != nil {
 			err := ierrors.NewError().InternalServer().Message(err.Error()).Build()
+
 			rest.ERROR(w, err)
 			return
 		}
-		log.Printf("string(signed) = %+v\n", string(signed))
+
+		server.logger.Info("new token", zap.String("value", string(signed)))
 
 		respBody := auth.JwtDO{
 			Token: signed,
@@ -87,7 +100,7 @@ func refreshPayload(refreshToken []byte, refreshURL string) (*auth.Payload, erro
 	c := &http.Client{}
 	resp, err := c.Post(refreshURL, "application/json", bytes.NewBuffer(reqBytes))
 	if err != nil || resp.StatusCode != http.StatusOK {
-		err = ierrors.NewError().InternalServer().InnerError(err).Build()
+		err = ierrors.NewError().InternalServer().Message(err.Error()).Build()
 		return nil, err
 	}
 	defer resp.Body.Close()

--- a/cmd/authsvc/api/controllers/refresh.go
+++ b/cmd/authsvc/api/controllers/refresh.go
@@ -20,7 +20,7 @@ func (server *Server) Refresh() rest.Handler {
 	return func(w http.ResponseWriter, r *http.Request) {
 		headerContent := r.Header["Authorization"]
 
-		server.logger.Info("headerContent:", zap.Any("content", headerContent))
+		server.logger.Debug("headerContent:", zap.Any("content", headerContent))
 		if len(headerContent) != 1 ||
 			!strings.HasPrefix(headerContent[0], "Bearer ") {
 			err := ierrors.NewError().Unauthorized().Message("bad Request, expected: Authorization: Bearer <token>").Build()
@@ -29,9 +29,9 @@ func (server *Server) Refresh() rest.Handler {
 		}
 
 		token := []byte(strings.TrimPrefix(headerContent[0], "Bearer "))
-		server.logger.Info("bearer token", zap.String("value", string(token)))
+		server.logger.Debug("bearer token", zap.String("value", string(token)))
 
-		server.logger.Debug("parsing received bearer token")
+		server.logger.Info("parsing received bearer token")
 		_, err := jwt.Parse(
 			token,
 			jwt.WithValidate(true),
@@ -45,7 +45,7 @@ func (server *Server) Refresh() rest.Handler {
 			return
 		}
 
-		server.logger.Debug("deserializing parsed token")
+		server.logger.Info("deserializing parsed token")
 		load, err := auth.Desserialize(token)
 		if err != nil {
 			err := ierrors.NewError().Forbidden().
@@ -55,9 +55,9 @@ func (server *Server) Refresh() rest.Handler {
 			return
 		}
 
-		server.logger.Info("received payload", zap.Any("content", load))
+		server.logger.Debug("received payload", zap.Any("content", load))
 
-		server.logger.Debug("refreshing old payload")
+		server.logger.Info("refreshing old payload")
 		payload, err := refreshPayload(load.Refresh, load.RefreshURL)
 		if err != nil {
 			err := ierrors.NewError().InternalServer().
@@ -67,7 +67,7 @@ func (server *Server) Refresh() rest.Handler {
 			return
 		}
 
-		server.logger.Info("refreshed payload", zap.Any("content", payload))
+		server.logger.Debug("refreshed payload", zap.Any("content", payload))
 
 		signed, err := server.tokenize(*payload, time.Now().Add(time.Minute*8))
 		if err != nil {
@@ -77,7 +77,7 @@ func (server *Server) Refresh() rest.Handler {
 			return
 		}
 
-		server.logger.Info("new token", zap.String("value", string(signed)))
+		server.logger.Debug("new token", zap.String("value", string(signed)))
 
 		respBody := auth.JwtDO{
 			Token: signed,

--- a/cmd/authsvc/api/controllers/refresh_test.go
+++ b/cmd/authsvc/api/controllers/refresh_test.go
@@ -88,7 +88,7 @@ func TestServer_Refresh(t *testing.T) {
 	// Private key in PEM format
 	privPEM := pem.EncodeToMemory(&privBlock)
 
-	// Configuring enviroment for tests
+	// Configuring environment for tests
 	os.Setenv("JWT_PRIVATE_KEY", string(privPEM))
 
 	server.Init()

--- a/cmd/authsvc/api/controllers/tokenize.go
+++ b/cmd/authsvc/api/controllers/tokenize.go
@@ -17,10 +17,15 @@ import (
 func (server *Server) Tokenize() rest.Handler {
 	return func(w http.ResponseWriter, r *http.Request) {
 		data := auth.Payload{}
+
 		err := json.NewDecoder(r.Body).Decode(&data)
 		if err != nil {
-			server.logger.Error("unable to decode ")
-			err = ierrors.NewError().BadRequest().Message("invalid body, error: %s", err.Error()).Build()
+			server.logger.Error("unable to decode payload",
+				zap.Any("error", err))
+
+			err = ierrors.NewError().BadRequest().
+				Message("invalid body, error: %s", err.Error()).Build()
+
 			rest.ERROR(w, err)
 			return
 		}

--- a/cmd/authsvc/api/controllers/tokenize.go
+++ b/cmd/authsvc/api/controllers/tokenize.go
@@ -52,7 +52,7 @@ func (server *Server) tokenize(payload auth.Payload, exp time.Time) ([]byte, err
 	signed, err := jwt.Sign(token, jwa.RS256, server.privKey)
 	if err != nil {
 		server.logger.Error("unable to sign JWT with provided RSA private key", zap.Any("error", err))
-		err := ierrors.NewError().InternalServer().Message("unable to sign JWT with availible RSA private key").Build()
+		err := ierrors.NewError().InternalServer().Message("unable to sign JWT with available RSA private key").Build()
 		return nil, err
 	}
 	return signed, nil

--- a/cmd/authsvc/api/controllers/tokenize_test.go
+++ b/cmd/authsvc/api/controllers/tokenize_test.go
@@ -63,7 +63,7 @@ func TestServer_Tokenize(t *testing.T) {
 	// Private key in PEM format
 	privPEM := pem.EncodeToMemory(&privBlock)
 
-	// Configuring enviroment for tests
+	// Configuring environment for tests
 	os.Setenv("JWT_PRIVATE_KEY", string(privPEM))
 
 	var server Server

--- a/cmd/insprd/memory/brokers/brokers.go
+++ b/cmd/insprd/memory/brokers/brokers.go
@@ -42,12 +42,12 @@ func (bmm *BrokerMemoryManager) Create(broker brokers.BrokerStatus, config broke
 		return ierrors.NewError().Message("broker %s is already configured on memory", broker).Build()
 	}
 	//configure the sidecarFactory for the given broker
-	//if succesful:
+	//if successful:
 	mem.Available[string(broker)] = true
 	return nil
 }
 
-// SetDefault sets a previoulsy configured broker as insprd's default broker
+// SetDefault sets a previously configured broker as insprd's default broker
 func (bmm *BrokerMemoryManager) SetDefault(broker brokers.BrokerStatus) error {
 	mem, err := bmm.get()
 	if err != nil {

--- a/cmd/insprd/memory/fake/brokers.go
+++ b/cmd/insprd/memory/fake/brokers.go
@@ -33,7 +33,7 @@ func (bks *BrokersMock) Create(broker brokers.BrokerStatus, config brokers.Broke
 	return nil
 }
 
-// SetDefault sets a previoulsy mocked broker as the fake's default broker
+// SetDefault sets a previously mocked broker as the fake's default broker
 func (bks *BrokersMock) SetDefault(broker brokers.BrokerStatus) error {
 	if bks.fail != nil {
 		return bks.fail

--- a/cmd/sidecars/kafka.go
+++ b/cmd/sidecars/kafka.go
@@ -35,7 +35,7 @@ func KafkaToDeployment(config KafkaConfig) models.SidecarFactory {
 	}
 }
 
-// KafkaEnvConfig adds teh necessary env variables to configure kafka
+// KafkaEnvConfig adds the necessary env variables to configure kafka
 func KafkaEnvConfig(config KafkaConfig) k8s.ContainerOption {
 	return k8s.ContainerWithEnv(
 		corev1.EnvVar{

--- a/cmd/uid_provider/api/handlers/handler_test.go
+++ b/cmd/uid_provider/api/handlers/handler_test.go
@@ -176,7 +176,7 @@ func TestHandler_UpdatePasswordHandler(t *testing.T) {
 				t.Log("error decoding payload into bytes")
 				return
 			}
-			req, _ := http.NewRequest("PUT", ts.URL, bytes.NewBuffer(body))
+			req, _ := http.NewRequest(http.MethodPut, ts.URL, bytes.NewBuffer(body))
 			res, err := client.Do(req)
 			if err != nil {
 				t.Log("error making a PUT in the httptest server")

--- a/cmd/uid_provider/api/handlers/handler_test.go
+++ b/cmd/uid_provider/api/handlers/handler_test.go
@@ -127,7 +127,7 @@ func TestHandler_DeleteUserHandler(t *testing.T) {
 				t.Log("error decoding payload into bytes")
 				return
 			}
-			req, _ := http.NewRequest("DELETE", ts.URL, bytes.NewBuffer(body))
+			req, _ := http.NewRequest(http.MethodDelete, ts.URL, bytes.NewBuffer(body))
 			res, err := client.Do(req)
 			if err != nil {
 				t.Log("error making a PUT in the httptest server")

--- a/cmd/uid_provider/client/client_test.go
+++ b/cmd/uid_provider/client/client_test.go
@@ -601,7 +601,7 @@ func Test_hasPermission(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "User has admin permisson",
+			name: "User has admin permission",
 			args: args{
 				uid: "user1",
 				pwd: "none",

--- a/cmd/uid_provider/client/client_test.go
+++ b/cmd/uid_provider/client/client_test.go
@@ -813,7 +813,7 @@ func mockRedis() *miniredis.Miniredis {
 }
 
 func insprServerHandler(w http.ResponseWriter, r *http.Request) {
-	if r.Method != "POST" {
+	if r.Method != http.MethodPost {
 		rest.ERROR(w, fmt.Errorf("method should be POST"))
 	}
 	data := auth.Payload{}

--- a/cmd/uid_provider/inprov/client/client.go
+++ b/cmd/uid_provider/inprov/client/client.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"net/http"
 	"os"
 
 	"github.com/inspr/inspr/cmd/uid_provider/api/models"
@@ -26,7 +27,7 @@ func NewClient() *Client {
 func (c *Client) Login(ctx context.Context, uid, pwd string) (string, error) {
 
 	var resp string
-	err := c.rc.Send(ctx, "/login", "POST", models.ReceivedDataLogin{UID: uid, Password: pwd}, &resp)
+	err := c.rc.Send(ctx, "/login", http.MethodPost, models.ReceivedDataLogin{UID: uid, Password: pwd}, &resp)
 	if err != nil {
 		return "", err
 	}
@@ -37,7 +38,7 @@ func (c *Client) Login(ctx context.Context, uid, pwd string) (string, error) {
 func (c *Client) CreateUser(ctx context.Context, uid, pwd string, newUser client.User) error {
 
 	var resp interface{}
-	err := c.rc.Send(ctx, "/newuser", "POST", models.ReceivedDataCreate{UID: uid, Password: pwd, User: newUser}, resp)
+	err := c.rc.Send(ctx, "/newuser", http.MethodPost, models.ReceivedDataCreate{UID: uid, Password: pwd, User: newUser}, resp)
 	return err
 }
 
@@ -45,7 +46,7 @@ func (c *Client) CreateUser(ctx context.Context, uid, pwd string, newUser client
 func (c *Client) DeleteUser(ctx context.Context, uid, pwd, usrToBeDeleted string) error {
 
 	var resp interface{}
-	err := c.rc.Send(ctx, "/deleteuser", "DELETE", models.ReceivedDataDelete{UID: uid, Password: pwd, UserToBeDeleted: usrToBeDeleted}, resp)
+	err := c.rc.Send(ctx, "/deleteuser", http.MethodDelete, models.ReceivedDataDelete{UID: uid, Password: pwd, UserToBeDeleted: usrToBeDeleted}, resp)
 	return err
 }
 
@@ -53,6 +54,6 @@ func (c *Client) DeleteUser(ctx context.Context, uid, pwd, usrToBeDeleted string
 func (c *Client) UpdatePassword(ctx context.Context, uid, pwd, usrToBeUpdated, newPwd string) error {
 
 	var resp interface{}
-	err := c.rc.Send(ctx, "/updatepwd", "PUT", models.ReceivedDataUpdate{UID: uid, Password: pwd, UserToBeUpdated: usrToBeUpdated, NewPassword: newPwd}, resp)
+	err := c.rc.Send(ctx, "/updatepwd", http.MethodPut, models.ReceivedDataUpdate{UID: uid, Password: pwd, UserToBeUpdated: usrToBeUpdated, NewPassword: newPwd}, resp)
 	return err
 }

--- a/cmd/uid_provider/inprov/client/client_test.go
+++ b/cmd/uid_provider/inprov/client/client_test.go
@@ -243,7 +243,7 @@ func TestClient_UpdatePassword(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			server := httptest.NewServer(rest.Handler(func(w http.ResponseWriter, r *http.Request) {
-				if r.Method != "PUT" {
+				if r.Method != http.MethodPut {
 					t.Errorf("method is not PUT")
 				}
 

--- a/cmd/uid_provider/inprov/client/client_test.go
+++ b/cmd/uid_provider/inprov/client/client_test.go
@@ -45,7 +45,7 @@ func TestClient_Login(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			server := httptest.NewServer(rest.Handler(func(w http.ResponseWriter, r *http.Request) {
-				if r.Method != "POST" {
+				if r.Method != http.MethodPost {
 					t.Errorf("method is not POST")
 				}
 
@@ -113,7 +113,7 @@ func TestClient_CreateUser(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			server := httptest.NewServer(rest.Handler(func(w http.ResponseWriter, r *http.Request) {
-				if r.Method != "POST" {
+				if r.Method != http.MethodPost {
 					t.Errorf("method is not POST")
 				}
 

--- a/cmd/uid_provider/inprov/client/client_test.go
+++ b/cmd/uid_provider/inprov/client/client_test.go
@@ -176,7 +176,7 @@ func TestClient_DeleteUser(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			server := httptest.NewServer(rest.Handler(func(w http.ResponseWriter, r *http.Request) {
-				if r.Method != "DELETE" {
+				if r.Method != http.MethodDelete {
 					t.Errorf("method is not DELETE")
 				}
 

--- a/cmd/uid_provider/inprov/user_example.yaml
+++ b/cmd/uid_provider/inprov/user_example.yaml
@@ -1,14 +1,14 @@
-uid: name
-password: password
+uid: bugtest
+password: "123"
 permissions:
   "":
     - "create:token"
-    
+
     - "create:dapp"
     - "create:channel"
     - "create:type"
     - "create:alias"
-    
+
     - "get:dapp"
     - "get:channel"
     - "get:type"

--- a/examples/controller/.dockerignore
+++ b/examples/controller/.dockerignore
@@ -1,0 +1,4 @@
+*/**
+!pkg
+!go.mod
+!examples/primes

--- a/examples/controller/main.go
+++ b/examples/controller/main.go
@@ -15,8 +15,8 @@ import (
 
 func main() {
 	dapp := meta.App{}
-	yaml.Unmarshal([]byte(yamls.PingPongYAML), &dapp)
-	dapp.Meta.Name = "controllerpingpong"
+	yaml.Unmarshal([]byte(yamls.PrimesYAML), &dapp)
+	dapp.Meta.Name = "controllerprimes"
 	config, err := client.GetInClusterConfigs()
 	if err != nil {
 		panic(err)
@@ -42,7 +42,7 @@ func main() {
 		}
 	})
 	mux.HandleFunc("/delete", func(rw http.ResponseWriter, r *http.Request) {
-		diff, err := c.Apps().Delete(context.Background(), "controllerpingpong", false)
+		diff, err := c.Apps().Delete(context.Background(), "controllerprimes", false)
 		diff.Print(os.Stdout)
 		if err != nil {
 			rest.ERROR(rw, err)

--- a/examples/controller/yamls/ingress.yaml
+++ b/examples/controller/yamls/ingress.yaml
@@ -11,13 +11,13 @@ spec:
         paths:
           - path: /update
             backend:
-              serviceName: node-393e2007-0f02-4971-80f6-3bd7af2f0463
+              serviceName: node-2cb79eff-d313-473f-8dd9-25defb1aed31
               servicePort: 8080
           - path: /delete
             backend:
-              serviceName: node-393e2007-0f02-4971-80f6-3bd7af2f0463
+              serviceName: node-2cb79eff-d313-473f-8dd9-25defb1aed31
               servicePort: 8080
           - path: /create
             backend:
-              serviceName: node-393e2007-0f02-4971-80f6-3bd7af2f0463
+              serviceName: node-2cb79eff-d313-473f-8dd9-25defb1aed31
               servicePort: 8080

--- a/examples/primes/yamls/pingpong.go
+++ b/examples/primes/yamls/pingpong.go
@@ -3,5 +3,6 @@ package yamls
 import _ "embed" // needs to be imported for embed to work
 
 //go:embed general.yaml
-// PingPongYAML is the yaml of the primes example
-var PingPongYAML string
+
+// PrimesYAML is the yaml of the primes example
+var PrimesYAML string

--- a/pkg/auth/jwt/auth.go
+++ b/pkg/auth/jwt/auth.go
@@ -57,8 +57,7 @@ func (JA *JWTauth) Validate(token []byte) (*auth.Payload, []byte, error) {
 					ierrors.
 						NewError().
 						InternalServer().
-						InnerError(err).
-						Message("error refreshing token").
+						Message("error refreshing token: %v", err).
 						Build()
 			}
 			token = newToken

--- a/pkg/auth/rsa-from-env.go
+++ b/pkg/auth/rsa-from-env.go
@@ -10,11 +10,11 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
-// GetPublicKey resolves the rssa public key from the enviroment variable.
+// GetPublicKey resolves the rsa public key from the environment variable
 func GetPublicKey() (*rsa.PublicKey, error) {
 	pubBytes, ok := os.LookupEnv("JWT_PUBLIC_KEY")
 	if !ok {
-		err := ierrors.NewError().Message("JWT_PUBLIC_KEY unavailible").Build()
+		err := ierrors.NewError().Message("JWT_PUBLIC_KEY unavailable").Build()
 		return nil, err
 	}
 	fmt.Printf("%s\n", pubBytes)

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -280,7 +280,7 @@ func TestClient_HandleChannel(t *testing.T) {
 			response := struct {
 				Status string `json:"status"`
 			}{}
-			err := client.Send(context.Background(), tt.args.channel, "POST", struct{ Message interface{} }{tt.message}, &response)
+			err := client.Send(context.Background(), tt.args.channel, http.MethodPost, struct{ Message interface{} }{tt.message}, &response)
 			if (response.Status != "OK") != tt.wantErr {
 				t.Errorf("Client_HandleChannel response.Status = %v, wantErr = %v", response.Status, tt.wantErr)
 			}
@@ -354,7 +354,7 @@ func TestClient_Run(t *testing.T) {
 			var response struct {
 				Status string `json:"status"`
 			}
-			err := c.Send(ctx, tt.channel, "POST", tt.message, &response)
+			err := c.Send(ctx, tt.channel, http.MethodPost, tt.message, &response)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Client_Run err = %v, wantErr = %v", err, tt.wantErr)
 			}

--- a/pkg/controller/client/alias.go
+++ b/pkg/controller/client/alias.go
@@ -32,7 +32,7 @@ func (ac *AliasClient) Get(ctx context.Context, scope, key string) (*meta.Alias,
 
 	err := ac.reqClient.
 		Header(rest.HeaderScopeKey, scope).
-		Send(ctx, "/alias", "GET", aliasQuery, &resp)
+		Send(ctx, "/alias", http.MethodGet, aliasQuery, &resp)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/client/alias.go
+++ b/pkg/controller/client/alias.go
@@ -112,7 +112,7 @@ func (ac *AliasClient) Update(ctx context.Context, scope string, target string, 
 
 	err := ac.reqClient.
 		Header(rest.HeaderScopeKey, scope).
-		Send(ctx, "/alias", "PUT", aliasQuery, &resp)
+		Send(ctx, "/alias", http.MethodPut, aliasQuery, &resp)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/client/alias.go
+++ b/pkg/controller/client/alias.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/inspr/inspr/pkg/api/models"
 	"github.com/inspr/inspr/pkg/meta"
@@ -58,7 +59,7 @@ func (ac *AliasClient) Create(ctx context.Context, scope string, target string, 
 
 	err := ac.reqClient.
 		Header(rest.HeaderScopeKey, scope).
-		Send(ctx, "/alias", "POST", aliasQuery, &resp)
+		Send(ctx, "/alias", http.MethodPost, aliasQuery, &resp)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/client/alias.go
+++ b/pkg/controller/client/alias.go
@@ -85,7 +85,7 @@ func (ac *AliasClient) Delete(ctx context.Context, scope, key string, dryRun boo
 
 	err := ac.reqClient.
 		Header(rest.HeaderScopeKey, scope).
-		Send(ctx, "/alias", "DELETE", aliasQuery, &resp)
+		Send(ctx, "/alias", http.MethodDelete, aliasQuery, &resp)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/client/alias_test.go
+++ b/pkg/controller/client/alias_test.go
@@ -66,7 +66,7 @@ func TestAliasClient_Get(t *testing.T) {
 					t.Errorf("path is not alias")
 				}
 
-				if r.Method != "GET" {
+				if r.Method != http.MethodGet {
 					t.Errorf("method is not GET")
 				}
 

--- a/pkg/controller/client/alias_test.go
+++ b/pkg/controller/client/alias_test.go
@@ -230,7 +230,7 @@ func TestAliasClient_Delete(t *testing.T) {
 					t.Errorf("path is not alias")
 				}
 
-				if r.Method != "DELETE" {
+				if r.Method != http.MethodDelete {
 					t.Errorf("method is not DELETE")
 				}
 

--- a/pkg/controller/client/alias_test.go
+++ b/pkg/controller/client/alias_test.go
@@ -154,7 +154,7 @@ func TestAliasClient_Create(t *testing.T) {
 					t.Errorf("path is not alias")
 				}
 
-				if r.Method != "POST" {
+				if r.Method != http.MethodPost {
 					t.Errorf("method is not POST")
 				}
 

--- a/pkg/controller/client/alias_test.go
+++ b/pkg/controller/client/alias_test.go
@@ -313,7 +313,7 @@ func TestAliasClient_Update(t *testing.T) {
 					t.Errorf("path is not alias")
 				}
 
-				if r.Method != "PUT" {
+				if r.Method != http.MethodPut {
 					t.Errorf("method is not PUT")
 				}
 

--- a/pkg/controller/client/auth.go
+++ b/pkg/controller/client/auth.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/inspr/inspr/pkg/auth"
 	"github.com/inspr/inspr/pkg/rest"
@@ -24,7 +25,7 @@ func (ac *AuthClient) GenerateToken(ctx context.Context, payload auth.Payload) (
 		*reqClient = reqClient.Header(rest.HeaderScopeKey, k)
 	}
 
-	err := reqClient.Send(ctx, "/auth", "POST", payload, &authDI)
+	err := reqClient.Send(ctx, "/auth", http.MethodPost, payload, &authDI)
 	if err != nil {
 		return "", err
 	}
@@ -38,7 +39,7 @@ func (ac *AuthClient) Init(ctx context.Context, key string) (string, error) {
 	authDO := struct{ Key string }{key}
 	authDI := auth.JwtDO{}
 
-	err := ac.reqClient.Send(ctx, "/init", "POST", authDO, &authDI)
+	err := ac.reqClient.Send(ctx, "/init", http.MethodPost, authDO, &authDI)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/controller/client/auth_test.go
+++ b/pkg/controller/client/auth_test.go
@@ -62,7 +62,7 @@ func TestAuthClient_GenerateToken(t *testing.T) {
 					t.Errorf("path is not auth")
 				}
 
-				if r.Method != "POST" {
+				if r.Method != http.MethodPost {
 					t.Errorf("method is not POST")
 				}
 

--- a/pkg/controller/client/brokers.go
+++ b/pkg/controller/client/brokers.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/inspr/inspr/pkg/api/models"
 	"github.com/inspr/inspr/pkg/rest/request"
@@ -16,7 +17,7 @@ type BrokersClient struct {
 func (cc *BrokersClient) Get(ctx context.Context) (*models.BrokersDI, error) {
 	resp := &models.BrokersDI{}
 
-	err := cc.reqClient.Send(ctx, "/brokers", "GET", nil, resp)
+	err := cc.reqClient.Send(ctx, "/brokers", http.MethodGet, nil, resp)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/client/brokers_test.go
+++ b/pkg/controller/client/brokers_test.go
@@ -58,7 +58,7 @@ func TestBrokersClient_Get(t *testing.T) {
 					t.Errorf("path is not channels")
 				}
 
-				if r.Method != "GET" {
+				if r.Method != http.MethodGet {
 					t.Errorf("method is not GET")
 				}
 

--- a/pkg/controller/client/channel.go
+++ b/pkg/controller/client/channel.go
@@ -109,7 +109,7 @@ func (cc *ChannelClient) Update(ctx context.Context, scope string, ch *meta.Chan
 
 	err := cc.reqClient.
 		Header(rest.HeaderScopeKey, scope).
-		Send(ctx, "/channels", "PUT", cdi, &resp)
+		Send(ctx, "/channels", http.MethodPut, cdi, &resp)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/client/channel.go
+++ b/pkg/controller/client/channel.go
@@ -83,7 +83,7 @@ func (cc *ChannelClient) Delete(ctx context.Context, scope string, name string, 
 
 	err := cc.reqClient.
 		Header(rest.HeaderScopeKey, scope).
-		Send(ctx, "/channels", "DELETE", cdi, &resp)
+		Send(ctx, "/channels", http.MethodDelete, cdi, &resp)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/client/channel.go
+++ b/pkg/controller/client/channel.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/inspr/inspr/pkg/api/models"
 	"github.com/inspr/inspr/pkg/meta"
@@ -56,7 +57,7 @@ func (cc *ChannelClient) Create(ctx context.Context, scope string, ch *meta.Chan
 
 	err := cc.reqClient.
 		Header(rest.HeaderScopeKey, scope).
-		Send(ctx, "/channels", "POST", cdi, &resp)
+		Send(ctx, "/channels", http.MethodPost, cdi, &resp)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/client/channel.go
+++ b/pkg/controller/client/channel.go
@@ -31,7 +31,7 @@ func (cc *ChannelClient) Get(ctx context.Context, scope string, name string) (*m
 
 	err := cc.reqClient.
 		Header(rest.HeaderScopeKey, scope).
-		Send(ctx, "/channels", "GET", cdi, &resp)
+		Send(ctx, "/channels", http.MethodGet, cdi, &resp)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/client/channel_test.go
+++ b/pkg/controller/client/channel_test.go
@@ -249,7 +249,7 @@ func TestChannelClient_Create(t *testing.T) {
 					t.Errorf("path is not channels")
 				}
 
-				if r.Method != "POST" {
+				if r.Method != http.MethodPost {
 					t.Errorf("method is not POST")
 				}
 

--- a/pkg/controller/client/channel_test.go
+++ b/pkg/controller/client/channel_test.go
@@ -150,7 +150,7 @@ func TestChannelClient_Get(t *testing.T) {
 					t.Errorf("path is not channels")
 				}
 
-				if r.Method != "GET" {
+				if r.Method != http.MethodGet {
 					t.Errorf("method is not GET")
 				}
 

--- a/pkg/controller/client/channel_test.go
+++ b/pkg/controller/client/channel_test.go
@@ -59,7 +59,7 @@ func TestChannelClient_Delete(t *testing.T) {
 					t.Errorf("path is not channels")
 				}
 
-				if r.Method != "DELETE" {
+				if r.Method != http.MethodDelete {
 					t.Errorf("method is not DELETE")
 				}
 

--- a/pkg/controller/client/channel_test.go
+++ b/pkg/controller/client/channel_test.go
@@ -339,7 +339,7 @@ func TestChannelClient_Update(t *testing.T) {
 					t.Errorf("path is not channels")
 				}
 
-				if r.Method != "PUT" {
+				if r.Method != http.MethodPut {
 					t.Errorf("method is not PUT")
 				}
 

--- a/pkg/controller/client/dapp.go
+++ b/pkg/controller/client/dapp.go
@@ -79,7 +79,7 @@ func (ac *AppClient) Delete(ctx context.Context, scope string, dryRun bool) (dif
 
 	err := ac.reqClient.
 		Header(rest.HeaderScopeKey, scope).
-		Send(ctx, "/apps", "DELETE", adi, &resp)
+		Send(ctx, "/apps", http.MethodDelete, adi, &resp)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/client/dapp.go
+++ b/pkg/controller/client/dapp.go
@@ -29,7 +29,7 @@ func (ac *AppClient) Get(ctx context.Context, scope string) (*meta.App, error) {
 
 	err := ac.reqClient.
 		Header(rest.HeaderScopeKey, scope).
-		Send(ctx, "/apps", "GET", adi, &resp)
+		Send(ctx, "/apps", http.MethodGet, adi, &resp)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/client/dapp.go
+++ b/pkg/controller/client/dapp.go
@@ -106,7 +106,7 @@ func (ac *AppClient) Update(ctx context.Context, scope string, app *meta.App, dr
 
 	err := ac.reqClient.
 		Header(rest.HeaderScopeKey, scope).
-		Send(ctx, "/apps", "PUT", adi, &resp)
+		Send(ctx, "/apps", http.MethodPut, adi, &resp)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/client/dapp.go
+++ b/pkg/controller/client/dapp.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/inspr/inspr/pkg/api/models"
 	"github.com/inspr/inspr/pkg/meta"
@@ -55,7 +56,7 @@ func (ac *AppClient) Create(ctx context.Context, scope string, app *meta.App, dr
 
 	err := ac.reqClient.
 		Header(rest.HeaderScopeKey, scope).
-		Send(ctx, "/apps", "POST", adi, &resp)
+		Send(ctx, "/apps", http.MethodPost, adi, &resp)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/client/dapp_test.go
+++ b/pkg/controller/client/dapp_test.go
@@ -340,7 +340,7 @@ func TestAppClient_Update(t *testing.T) {
 					t.Errorf("path is not apps")
 				}
 
-				if r.Method != "PUT" {
+				if r.Method != http.MethodPut {
 					t.Errorf("method is not PUT")
 				}
 

--- a/pkg/controller/client/dapp_test.go
+++ b/pkg/controller/client/dapp_test.go
@@ -246,7 +246,7 @@ func TestAppClient_Create(t *testing.T) {
 					t.Errorf("path is not apps")
 				}
 
-				if r.Method != "POST" {
+				if r.Method != http.MethodPost {
 					t.Errorf("method is not POST")
 				}
 

--- a/pkg/controller/client/dapp_test.go
+++ b/pkg/controller/client/dapp_test.go
@@ -58,7 +58,7 @@ func TestAppClient_Delete(t *testing.T) {
 					t.Errorf("path is not apps")
 				}
 
-				if r.Method != "DELETE" {
+				if r.Method != http.MethodDelete {
 					t.Errorf("method is not DELETE")
 				}
 

--- a/pkg/controller/client/dapp_test.go
+++ b/pkg/controller/client/dapp_test.go
@@ -150,7 +150,7 @@ func TestAppClient_Get(t *testing.T) {
 					t.Errorf("path is not apps")
 				}
 
-				if r.Method != "GET" {
+				if r.Method != http.MethodGet {
 					t.Errorf("method is not GET")
 				}
 

--- a/pkg/controller/client/type.go
+++ b/pkg/controller/client/type.go
@@ -31,7 +31,7 @@ func (tc *TypeClient) Get(ctx context.Context, scope string, name string) (*meta
 
 	err := tc.reqClient.
 		Header(rest.HeaderScopeKey, scope).
-		Send(ctx, "/types", "GET", tdi, &resp)
+		Send(ctx, "/types", http.MethodGet, tdi, &resp)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/client/type.go
+++ b/pkg/controller/client/type.go
@@ -83,7 +83,7 @@ func (tc *TypeClient) Delete(ctx context.Context, scope string, name string, dry
 
 	err := tc.reqClient.
 		Header(rest.HeaderScopeKey, scope).
-		Send(ctx, "/types", "DELETE", tdi, &resp)
+		Send(ctx, "/types", http.MethodDelete, tdi, &resp)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/client/type.go
+++ b/pkg/controller/client/type.go
@@ -109,7 +109,7 @@ func (tc *TypeClient) Update(ctx context.Context, scope string, ch *meta.Type, d
 
 	err := tc.reqClient.
 		Header(rest.HeaderScopeKey, scope).
-		Send(ctx, "/types", "PUT", tdi, &resp)
+		Send(ctx, "/types", http.MethodPut, tdi, &resp)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/client/type.go
+++ b/pkg/controller/client/type.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/inspr/inspr/pkg/api/models"
 	"github.com/inspr/inspr/pkg/meta"
@@ -56,7 +57,7 @@ func (tc *TypeClient) Create(ctx context.Context, scope string, ch *meta.Type, d
 
 	err := tc.reqClient.
 		Header(rest.HeaderScopeKey, scope).
-		Send(ctx, "/types", "POST", tdi, &resp)
+		Send(ctx, "/types", http.MethodPost, tdi, &resp)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/client/type_test.go
+++ b/pkg/controller/client/type_test.go
@@ -144,7 +144,7 @@ func TestTypeClient_Get(t *testing.T) {
 					t.Errorf("path is not types")
 				}
 
-				if r.Method != "GET" {
+				if r.Method != http.MethodGet {
 					t.Errorf("method is not GET")
 				}
 

--- a/pkg/controller/client/type_test.go
+++ b/pkg/controller/client/type_test.go
@@ -317,7 +317,7 @@ func TestTypeClient_Update(t *testing.T) {
 					t.Errorf("path is not types")
 				}
 
-				if r.Method != "PUT" {
+				if r.Method != http.MethodPut {
 					t.Errorf("method is not PUT")
 				}
 

--- a/pkg/controller/client/type_test.go
+++ b/pkg/controller/client/type_test.go
@@ -233,7 +233,7 @@ func TestTypeClient_Create(t *testing.T) {
 					t.Errorf("path is not types")
 				}
 
-				if r.Method != "POST" {
+				if r.Method != http.MethodPost {
 					t.Errorf("method is not POST")
 				}
 

--- a/pkg/controller/client/type_test.go
+++ b/pkg/controller/client/type_test.go
@@ -59,7 +59,7 @@ func TestTypeClient_Delete(t *testing.T) {
 					t.Errorf("path is not types")
 				}
 
-				if r.Method != "DELETE" {
+				if r.Method != http.MethodDelete {
 					t.Errorf("method is not DELETE")
 				}
 

--- a/pkg/meta/utils/diff/diff.go
+++ b/pkg/meta/utils/diff/diff.go
@@ -508,7 +508,6 @@ func (change *Change) diffTypes(from, to metautils.MTypes) error {
 }
 
 func (change *Change) diffMetadata(parentElement string, parentKind Kind, from, to meta.Metadata, ctx string) error {
-	var errs string
 
 	if from.Name != to.Name {
 		change.Diff = append(change.Diff, Difference{
@@ -537,7 +536,6 @@ func (change *Change) diffMetadata(parentElement string, parentKind Kind, from, 
 	}
 
 	if from.Parent != to.Parent {
-		errs += fmt.Sprintf("on %s Metadata: Different parent", ctx)
 		change.Diff = append(change.Diff, Difference{
 			Field:     ctx + "Meta.Parent",
 			From:      from.Parent,

--- a/pkg/operator/k8s/container.go
+++ b/pkg/operator/k8s/container.go
@@ -40,7 +40,7 @@ func ContainerWithEnv(env ...corev1.EnvVar) ContainerOption {
 	}
 }
 
-// ContainerWithEnvFrom adds envirnoment variables from a source to a container
+// ContainerWithEnvFrom adds environment variables from a source to a container
 func ContainerWithEnvFrom(env ...corev1.EnvFromSource) ContainerOption {
 	return func(c *corev1.Container) {
 		c.EnvFrom = append(c.EnvFrom, env...)

--- a/pkg/rest/constants.go
+++ b/pkg/rest/constants.go
@@ -9,7 +9,7 @@ const (
 	HeaderScopeKey = "Scope"
 )
 
-// operationTranslator receives a http.Method and proceedes to translate into a
+// operationTranslator receives a http.Method and proceeds to translate into a
 // string that represents the operation that will be done in the insprd
 var operationTranslator = map[string]string{
 	http.MethodGet:    "get",

--- a/pkg/rest/middleware.go
+++ b/pkg/rest/middleware.go
@@ -91,7 +91,7 @@ func (h Handler) Validate(auth auth.Auth) Handler {
 
 		// error management
 		if err != nil {
-			// check for invalid error or non Existant
+			// check for invalid error or non existent
 			if ierrors.HasCode(err, ierrors.InvalidToken) {
 
 				ERROR(w, ierrors.NewError().Unauthorized().Message("invalid token").Build())
@@ -153,7 +153,8 @@ func getOperation(r *http.Request) string {
 }
 
 // getTarget isolates the area that is being requested, for example the request
-// URL is https://example.org:8000/channels, the getTarget removes the base of the url and some unecessary '/' and returns only 'channels'
+// URL is https://example.org:8000/channels, the getTarget removes the base of the url
+// and some unnecessary '/' and returns only 'channels'
 func getTarget(r *http.Request) string {
 	route := strings.TrimSuffix(r.URL.Path, "/")
 	route = strings.TrimPrefix(route, r.URL.Host)

--- a/pkg/rest/middleware_test.go
+++ b/pkg/rest/middleware_test.go
@@ -48,7 +48,7 @@ func TestHandler_JSON(t *testing.T) {
 
 	for _, tt := range tests {
 		// sets up the test server
-		req, err := http.NewRequest("GET", tt.routeName, nil)
+		req, err := http.NewRequest(http.MethodGet, tt.routeName, nil)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/rest/request/request_test.go
+++ b/pkg/rest/request/request_test.go
@@ -49,7 +49,7 @@ func TestClient_Send(t *testing.T) {
 			args: args{
 				ctx:    context.Background(),
 				route:  "/test",
-				method: "POST",
+				method: http.MethodPost,
 				body:   "hello",
 			},
 			wantErr: false,
@@ -120,7 +120,7 @@ func TestClient_Send(t *testing.T) {
 			args: args{
 				ctx:    context.Background(),
 				route:  "/test",
-				method: "POST",
+				method: http.MethodPost,
 				body:   "hello",
 			},
 			wantErr: true,
@@ -138,7 +138,7 @@ func TestClient_Send(t *testing.T) {
 			args: args{
 				ctx:    context.Background(),
 				route:  "/test",
-				method: "POST",
+				method: http.MethodPost,
 				body:   "hello",
 			},
 			wantErr: true,

--- a/pkg/rest/request/request_test.go
+++ b/pkg/rest/request/request_test.go
@@ -66,7 +66,7 @@ func TestClient_Send(t *testing.T) {
 			args: args{
 				ctx:    context.Background(),
 				route:  "/test",
-				method: "GET",
+				method: http.MethodGet,
 				body:   "hello",
 			},
 			wantErr: false,
@@ -83,7 +83,7 @@ func TestClient_Send(t *testing.T) {
 			args: args{
 				ctx:    context.Background(),
 				route:  "/test",
-				method: "GET",
+				method: http.MethodGet,
 				body:   "hello",
 			},
 			wantErr:    true,
@@ -103,7 +103,7 @@ func TestClient_Send(t *testing.T) {
 			args: args{
 				ctx:    context.Background(),
 				route:  "/test",
-				method: "GET",
+				method: http.MethodGet,
 				body:   "hello",
 			},
 			wantErr: true,

--- a/pkg/sidecar_old/server/handlers_test.go
+++ b/pkg/sidecar_old/server/handlers_test.go
@@ -135,7 +135,7 @@ func TestServer_writeMessageHandler(t *testing.T) {
 				Status string `json:"status"`
 			}{}
 
-			err := client.Send(context.Background(), tt.channel, "POST", tt.message, &rest)
+			err := client.Send(context.Background(), tt.channel, http.MethodPost, tt.message, &rest)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Server_writeMessageHandler err = %v, wantErr = %v", err, tt.wantErr)
 			}

--- a/pkg/sidecars/lbsidecar/handlers.go
+++ b/pkg/sidecars/lbsidecar/handlers.go
@@ -20,9 +20,7 @@ import (
 var logger *zap.Logger
 
 func init() {
-	logger = zap.NewNop()
-
-	// logger, _ = zap.NewProduction(zap.Fields(zap.String("section", "loadbalencer-sidecar")))
+	logger, _ = zap.NewDevelopment(zap.Fields(zap.String("section", "loadbalencer-sidecar")))
 }
 
 // writeMessageHandler handles requests sent to the write message server


### PR DESCRIPTION
# Description

Kind: Bugfix and Refactor
<!-- Specify the kind of the pull request, as in if it's a Bug fix, a Feature, a Story, a Tech Pendency, etc.
-->

Section: Auth
<!-- Section can be the specific folder or file refered by the pull request, like "pkg/ierrors", or a most wide section that comprehends multiple folders and files, like "Sidecar".
-->

Summary: Last sprint we had a bug that when the auth token expires, Insprd proceeded to refresh it and a crash happened/the token wasn't refreshed.  
Despite trying to replicate this bug in many different ways, I wasn't able to do so. In all cases the tokens were properly refresh and kept working.  
For that, as this was a 5 point task, I proceeded to do some refactors in logs, errors, constants and etc.
<!-- A quick description of what was changed, fixed or implemented (e.g. "Configured all Insprd routes to validate authentication")
-->

## Changelog

> Improved some error's messages  
> Changed some logs so they use `zap.logger` and improved their messages
> Fixed misspelings
> Changed "POST", "GET", "DELETE" and "PUT" to use `net/http` constants instead
> Lowered the token's expiration time

## Pay attention to

**List of tried test cases:**
- Initialize Insprd and UID Provider, and used the Admin user to make requests to Insprd
    - Waited for the Admin user token expire and tried again
- Created a new user, with all permissions on the root scope and did the same tests
- Created a new user with all permissions on a specific scope and did the same tests
    - For this user, requests to actions/scopes it didn't have permission to were also done
- Created a new user with restricted permissions on a specific scope and did the same tests
    - For this user, requests to actions/scopes it didn't have permission to were also done
- Created a Controller dApp (using `inspr/examples/controller`) and ran the same tests
