### PR TITLE
Tech CORE-430 | Refactor memory dApp section

### DIFF
--- a/.github/scripts/update_tags.sh
+++ b/.github/scripts/update_tags.sh
@@ -3,16 +3,22 @@ CHART_URL=$1
 CHART_GS_URI=$2
 echo "Updating helm chart tags"
 INSPRD_TAG=$(printf '%s' $(grep -Eo "gcr\.io\/red\-inspr\/insprd\:[^@]+\@sha256\:[[:alnum:]]+" tags.out) | sed -e 's/[\/&]/\\&/g')
-KAFKA_SIDECAR_TAG=$(printf '%s' $(grep -Eo "gcr\.io\/red\-inspr\/inspr\/sidecar\/kafka\:[^@]+\@sha256\:[[:alnum:]]+" tags.out) | sed -e 's/[\/&]/\\&/g')
+LB_SIDECAR_TAG=$(printf '%s' $(grep -Eo "gcr\.io\/red\-inspr\/inspr\/sidecar\/lbsidecar\:[^@]+\@sha256\:[[:alnum:]]+" tags.out) | sed -e 's/[\/&]/\\&/g')
+AUTHSVC_TAG=$(printf '%s' $(grep -Eo "gcr\.io\/red\-inspr\/authsvc\:[^@]+\@sha256\:[[:alnum:]]+" tags.out) | sed -e 's/[\/&]/\\&/g')
+SECRETGEN_TAG=$(printf '%s' $(grep -Eo "gcr\.io\/red\-inspr\/secretgen\:[^@]+\@sha256\:[[:alnum:]]+" tags.out) | sed -e 's/[\/&]/\\&/g')
 
 echo
 echo "Tags for updating:"
 echo "$INSPRD_TAG"
-echo "$KAFKA_SIDECAR_TAG"
+echo "$LB_SIDECAR_TAG"
+echo "$AUTHSVC_TAG"
+echo "$SECRETGEN_TAG"
 
 echo "Updating tags"
 sed -i 's/gcr\.io\/red\-inspr\/insprd/'"$INSPRD_TAG"'/'  build/helm/values.yaml
-sed -i 's/gcr\.io\/red\-inspr\/inspr\/sidecar\/kafka/'"$KAFKA_SIDECAR_TAG"'/' build/helm/values.yaml
+sed -i 's/gcr\.io\/red\-inspr\/inspr\/sidecar\/lbsidecar/'"$LB_SIDECAR_TAG"'/' build/helm/values.yaml
+sed -i 's/gcr\.io\/red\-inspr\/authsvc/'"$AUTHSVC_TAG"'/'  build/helm/values.yaml
+sed -i 's/gcr\.io\/red\-inspr\/secretgen/'"$SECRETGEN_TAG"'/'  build/helm/values.yaml
 
 APP_VERSION=$(git describe --always --tags)
 echo "Updating chart app version to $APP_VERSION"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 
 # Changelog
 
+### #74 Tech CORE-430 | Refactor memory dApp section 
+- refactors:
+    - Update error messages so they use Sprintf structure and aren't duplicated in `dapp_utils.go`
+    - Methods in `dapp_utils.go` now use multi-error structure
+    - Removed unused methods in `dapp_utils.go`
+- fixes
+    - Added LB Sidecar, Authsvc and Secretgen images tag update in Helm Chart update script
+---
+
 ### #73 Tech CORE-461 | Rename inspr CLI as insprctl
 - misc:
     - Renamed folder `cmd/inspr` to `cmd/insprctl`

--- a/cmd/insprd/memory/tree/dapp.go
+++ b/cmd/insprd/memory/tree/dapp.go
@@ -202,7 +202,7 @@ func (amm *AppRootGetter) Get(query string) (*meta.App, error) {
 	}
 
 	reference := strings.Split(query, ".")
-	err := ierrors.NewError().NotFound().Message("dApp not found for given query: " + query).Build()
+	err := ierrors.NewError().NotFound().Message("dApp not found for given query '%v'", query).Build()
 
 	nextApp := amm.tree
 	if nextApp != nil {

--- a/cmd/insprd/memory/tree/dapp_utils_test.go
+++ b/cmd/insprd/memory/tree/dapp_utils_test.go
@@ -25,9 +25,9 @@ func Test_validAppStructure(t *testing.T) {
 		parentApp meta.App
 	}
 	tests := []struct {
-		name string
-		args args
-		want string
+		name    string
+		args    args
+		wantErr bool
 	}{
 		{
 			name: "All valid structures",
@@ -64,7 +64,6 @@ func Test_validAppStructure(t *testing.T) {
 				},
 				parentApp: *getMockApp().Spec.Apps["app2"],
 			},
-			want: "",
 		},
 		{
 			name: "invalidapp name - empty",
@@ -101,7 +100,7 @@ func Test_validAppStructure(t *testing.T) {
 				},
 				parentApp: *getMockApp().Spec.Apps["app2"],
 			},
-			want: "invalid dApp name;",
+			wantErr: true,
 		},
 		{
 			name: "invalidapp substructure",
@@ -140,7 +139,7 @@ func Test_validAppStructure(t *testing.T) {
 				},
 				parentApp: *getMockApp().Spec.Apps["app2"],
 			},
-			want: "invalid substructure;",
+			wantErr: true,
 		},
 		{
 			name: "invalidapp - parent has Node structure",
@@ -177,13 +176,19 @@ func Test_validAppStructure(t *testing.T) {
 				},
 				parentApp: *getMockApp().Spec.Apps["appNode"],
 			},
-			want: "parent has Node;",
+			wantErr: true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := validAppStructure(&tt.args.app, &tt.args.parentApp); got != tt.want {
-				t.Errorf("validAppStructure() = %v, want %v", got, tt.want)
+			err := validAppStructure(&tt.args.app, &tt.args.parentApp)
+			if tt.wantErr && (err == nil) {
+				t.Errorf("validAppStructure(): wanted error but received 'nil'")
+				return
+			}
+
+			if !tt.wantErr && (err != nil) {
+				t.Errorf("validAppStructure() error: %v", reflect.TypeOf(err))
 			}
 		})
 	}
@@ -326,10 +331,9 @@ func Test_checkAndUpdates(t *testing.T) {
 		app *meta.App
 	}
 	tests := []struct {
-		name  string
-		args  args
-		want  bool
-		want1 string
+		name    string
+		args    args
+		wantErr bool
 	}{
 		{
 			name: "valid channel structure - it shouldn't return a error",
@@ -401,8 +405,6 @@ func Test_checkAndUpdates(t *testing.T) {
 					},
 				},
 			},
-			want:  true,
-			want1: "",
 		},
 		{
 			name: "invalid channel: using non-existent type",
@@ -474,8 +476,7 @@ func Test_checkAndUpdates(t *testing.T) {
 					},
 				},
 			},
-			want:  false,
-			want1: "invalid channel: using non-existent type;",
+			wantErr: true,
 		},
 		{
 			name: "invalid channel structure - it should return a name channel error",
@@ -547,8 +548,7 @@ func Test_checkAndUpdates(t *testing.T) {
 					},
 				},
 			},
-			want:  false,
-			want1: "invalid channel name: invalid.channel.name",
+			wantErr: true,
 		},
 		{
 			name: "valid channel structure - it shouldn't return a error",
@@ -620,18 +620,19 @@ func Test_checkAndUpdates(t *testing.T) {
 					},
 				},
 			},
-			want:  false,
-			want1: "invalid type name: invalid.type",
+			wantErr: true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, got1 := checkAndUpdates(tt.args.app)
-			if got != tt.want {
-				t.Errorf("checkChannels() got = %v, want %v", got, tt.want)
+			err := checkAndUpdates(tt.args.app)
+			if tt.wantErr && (err == nil) {
+				t.Errorf("checkAndUpdates(): wanted error but received 'nil'")
+				return
 			}
-			if got1 != tt.want1 {
-				t.Errorf("checkChannels() got1 = %v, want %v", got1, tt.want1)
+
+			if !tt.wantErr && (err != nil) {
+				t.Errorf("checkAndUpdates() error: %v", err)
 			}
 		})
 	}
@@ -1219,35 +1220,28 @@ func Test_validAliases(t *testing.T) {
 		app *meta.App
 	}
 	tests := []struct {
-		name  string
-		args  args
-		valid bool
-		msg1  string
-		msg2  string
+		name    string
+		args    args
+		wantErr bool
 	}{
 		{
 			name: "test alias validation",
 			args: args{
 				app: &appTest,
 			},
-			valid: false,
-			msg1:  "alias: invalid.alias2 points to an non-existent channel 'ch4'; alias: invalid.alias1 points to an non-existent channel 'ch3'",
-			msg2:  "alias: invalid.alias1 points to an non-existent channel 'ch3'; alias: invalid.alias2 points to an non-existent channel 'ch4'",
+			wantErr: true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, got1 := validAliases(tt.args.app)
-			if got != tt.valid {
-				t.Errorf("validAliases() got = %v, want %v", got, tt.valid)
+			err := validAliases(tt.args.app)
+			if tt.wantErr && (err == nil) {
+				t.Errorf("validAliases(): wanted error but received 'nil'")
+				return
 			}
-			if got1 != tt.msg1 && got1 != tt.msg2 {
-				if got1 != tt.msg1 {
-					t.Errorf("validAliases() got1 = %v, want %v", got1, tt.msg1)
-				}
-				if got1 != tt.msg2 {
-					t.Errorf("validAliases() got1 = %v, want %v", got1, tt.msg2)
-				}
+
+			if !tt.wantErr && (err != nil) {
+				t.Errorf("validAliases() error: %v", err)
 			}
 		})
 	}

--- a/pkg/meta/utils/scope.go
+++ b/pkg/meta/utils/scope.go
@@ -10,6 +10,7 @@ import (
 // IsValidScope checks if the given scope is of the type
 // 'name1.name2.name3'
 func IsValidScope(scope string) bool {
+	// len of "" is 0 and the scope of the root dApp
 	if len(scope) == 0 {
 		return true
 	}


### PR DESCRIPTION
# Description

Kind: Tech Pendency
<!-- Specify the kind of the pull request, as in if it's a Bug fix, a Feature, a Story, a Tech Pendency, etc.
-->

Section: Insprd memory and GitHub Actions script
<!-- Section can be the specific folder or file refered by the pull request, like "pkg/ierrors", or a most wide section that comprehends multiple folders and files, like "Sidecar".
-->

Summary: Refactored dApp utils section to be more readable and understandable. Also fixed the script that updated the Helm Chart when creating a new GitHub release
<!-- A quick description of what was changed, fixed or implemented (e.g. "Configured all Insprd routes to validate authentication")
-->

## Changelog

> Update error messages so they use `Sprintf` structure and aren't duplicated
> Methods in `dapp_utils.go` now use multi-error structure
> Removed unused methods
> Added LB Sidecar, Authsvc and Secretgen images tag update in Helm Chart update script   

## Pay attention to

> There might be space for better improving the dapp_utils section. If something doesn't seem nice let me know.
