### PR TITLE
Bug CORE-475 | Deletion of multiple channels not working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
     - Fixed Insprd CLI's Alias delete command (and its tests)
 - refactors:
     - In the tree memory manager renamed method Root(), which returns the tree, to Tree()
+    - In the tree memory manager, renamed "RootGetter" structures to "TreeGetter"
 - misc:
     - Updated Insprd CLI's cluster config command error messages
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
     - Fixed Insprd CLI's Alias delete command (and its tests)
 - refactors:
     - In the tree memory manager renamed method Root(), which returns the tree, to Tree()
-    - In the tree memory manager, renamed "RootGetter" structures to "TreeGetter"
+    - In the tree memory manager, renamed "RootGetter" structures to "PermTreeGetter"
 - misc:
     - Updated Insprd CLI's cluster config command error messages
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,20 @@
 
 # Changelog
 
+### #78 Bug CORE-475 | Deletion of multiple channels not working  
+- fixes:
+    - Altered the Channel Operator when handling delete to get the channel from `tree` instead of `root`
+    - Fixed Insprd CLI's Alias delete command (and its tests)
+- refactors:
+    - In the tree memory manager renamed method Root(), which returns the tree, to Tree()
+- misc:
+    - Updated Insprd CLI's cluster config command error messages
+---
+
+## Release v0.1.0
+
 ### #76 Tech CORE-360 | vanity url
-- fix:
+- fixes:
   - changed the `module` name in the `go mod` of the project, that allows the vanity url in the productions cluster to obtain the package properly
 ---
 

--- a/build/uidp_helm/values.yaml
+++ b/build/uidp_helm/values.yaml
@@ -41,7 +41,7 @@ secretRepository: gcr.io/red-inspr/uidp/redis/secret
 secret:
   privateKeyName: redisprivatekey
   adminPassword: "123456"
-  adminToken: eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2MjQzODQyODUsInBheWxvYWQiOnsidWlkIjoiIiwicGVybWlzc2lvbnMiOnsiIjpbImNyZWF0ZTp0b2tlbiJdfSwicmVmcmVzaCI6bnVsbCwicmVmcmVzaHVybCI6IiJ9fQ.IS2aLgFtvGuc89eAfIEYM8nb5DV7_uVBFFnJXaqY-DUNI1Zr5vi076VVdWRPKGgdZ45U0v0-pIpKSAUV5XfheA
+  adminToken: eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2MjQ0NTAyOTEsInBheWxvYWQiOnsidWlkIjoiIiwicGVybWlzc2lvbnMiOnsiIjpbImNyZWF0ZTp0b2tlbiJdfSwicmVmcmVzaCI6bnVsbCwicmVmcmVzaHVybCI6IiJ9fQ.MjetV_IuKVQsdixy8icZsZ6Ue3cnI6HKvIS0UCKA30fhBi1_ca7tNqy6oys05iMK0jZIfXztZv1p6p-Z-w6hqA
   # set this admin token from a token that contains full power over the cluster
 
 statefulset:

--- a/build/uidp_helm/values.yaml
+++ b/build/uidp_helm/values.yaml
@@ -41,7 +41,7 @@ secretRepository: gcr.io/red-inspr/uidp/redis/secret
 secret:
   privateKeyName: redisprivatekey
   adminPassword: "123456"
-  adminToken: eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2MjQwMjIzNDgsInBheWxvYWQiOnsidWlkIjoiIiwicGVybWlzc2lvbnMiOnsiIjpbImNyZWF0ZTp0b2tlbiJdfSwicmVmcmVzaCI6bnVsbCwicmVmcmVzaHVybCI6IiJ9fQ.ZRWTnNBwiM5jg-Tmv_aCVlhZlKCgFcXN3oZ8HrvlHBhdtbAKK1bOI1Bc3nI-KUolGVBepK4XnPgB53B2yp1WKg
+  adminToken: eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2MjQzODQyODUsInBheWxvYWQiOnsidWlkIjoiIiwicGVybWlzc2lvbnMiOnsiIjpbImNyZWF0ZTp0b2tlbiJdfSwicmVmcmVzaCI6bnVsbCwicmVmcmVzaHVybCI6IiJ9fQ.IS2aLgFtvGuc89eAfIEYM8nb5DV7_uVBFFnJXaqY-DUNI1Zr5vi076VVdWRPKGgdZ45U0v0-pIpKSAUV5XfheA
   # set this admin token from a token that contains full power over the cluster
 
 statefulset:

--- a/cmd/insprctl/cli/cluster.go
+++ b/cmd/insprctl/cli/cluster.go
@@ -8,7 +8,6 @@ import (
 	"github.com/spf13/cobra"
 	"inspr.dev/inspr/pkg/cmd"
 	"inspr.dev/inspr/pkg/cmd/utils"
-	cliutils "inspr.dev/inspr/pkg/cmd/utils"
 	"inspr.dev/inspr/pkg/ierrors"
 )
 
@@ -71,39 +70,39 @@ func authInit(c context.Context, args []string) error {
 }
 
 func clusterConfig(c context.Context, args []string) error {
-	client := cliutils.GetCliClient()
+	client := utils.GetCliClient()
 	output := utils.GetCliOutput()
 	brokerName, filePath := args[0], args[1]
 
-	if err := cliutils.CheckEmptyArgs(map[string]string{
+	if err := utils.CheckEmptyArgs(map[string]string{
 		"brokerName": brokerName,
 		"filePath":   filePath,
 	}); err != nil {
-		fmt.Fprintf(output, err.Error())
+		fmt.Fprintf(output, "invalid args: %v\n", err.Error())
 		return err
 	}
 
 	// check if file exists and if it is a yaml file
 	if _, err := os.Stat(filePath); os.IsNotExist(err) || !isYaml(filePath) {
 		if err != nil {
-			fmt.Fprintf(output, err.Error())
+			fmt.Fprintf(output, "unable to find file: %v\n", err.Error())
 			return err
 		}
 
-		fmt.Fprintf(output, "not a yaml file")
+		fmt.Fprintf(output, "not a yaml file\n")
 		return ierrors.NewError().Message("not a yaml file").InvalidFile().Build()
 	}
 
 	bytes, err := os.ReadFile(filePath)
 	if err != nil {
-		fmt.Fprintf(output, err.Error())
+		fmt.Fprintf(output, "unable to read file: %v\n", err.Error())
 		return err
 	}
 
 	// do a request to the broker route /brokers/<broker_name>
 	err = client.Brokers().Create(context.Background(), brokerName, bytes)
 	if err != nil {
-		fmt.Fprintf(output, err.Error())
+		fmt.Fprintf(output, "unable to create broker: %v\n", err.Error())
 		return err
 	}
 

--- a/cmd/insprctl/cli/cluster_test.go
+++ b/cmd/insprctl/cli/cluster_test.go
@@ -194,31 +194,31 @@ func Test_clusterConfig(t *testing.T) {
 		{
 			name:    "filePath_empty",
 			args:    []string{"config", "kafka", ""},
-			wantMsg: "arg 'filePath' is empty",
+			wantMsg: "invalid args: arg 'filePath' is empty\n",
 			wantErr: true,
 		},
 		{
 			name:    "configName_empty",
 			args:    []string{"config", "", invalidFile},
-			wantMsg: "arg 'brokerName' is empty",
+			wantMsg: "invalid args: arg 'brokerName' is empty\n",
 			wantErr: true,
 		},
 		{
 			name:    "non_existant_config_file",
 			args:    []string{"config", "kafka", dir + "nonExistantFile.yml"},
-			wantMsg: nonExistantMessage,
+			wantMsg: "unable to find file: " + nonExistantMessage + "\n",
 			wantErr: true,
 		},
 		{
 			name:    "non_yaml_config_file",
 			args:    []string{"config", "kafka", nonYamlFile},
-			wantMsg: "not a yaml file",
+			wantMsg: "not a yaml file\n",
 			wantErr: true,
 		},
 		{
 			name:    "failed_client_create",
 			args:    []string{"config", "kafka", kafkaFile},
-			wantMsg: clientMockErr.Error(),
+			wantMsg: "unable to create broker: " + clientMockErr.Error() + "\n",
 			wantErr: true,
 		},
 		{

--- a/cmd/insprctl/cli/delete.go
+++ b/cmd/insprctl/cli/delete.go
@@ -161,7 +161,7 @@ func deleteAlias(_ context.Context, args []string) error {
 	}
 
 	for _, arg := range args {
-		path, aliasKey, err := cliutils.ProcessArg(arg, scope)
+		path, aliasKey, err := cliutils.ProcessAliasArg(arg, scope)
 		if err != nil {
 			return err
 		}

--- a/cmd/insprctl/cli/delete.go
+++ b/cmd/insprctl/cli/delete.go
@@ -17,9 +17,9 @@ import (
 func NewDeleteCmd() *cobra.Command {
 	deleteApps := cmd.NewCmd("apps").
 		WithDescription("Delete apps from scope").
-		WithAliases("a").
 		WithExample("Delete app from the default scope", "delete apps <appname> ").
 		WithExample("Delete app from a custom scope", "delete apps <appname> --scope app1.app2").
+		WithAliases("a").
 		WithCommonFlags().
 		MinimumArgs(1, deleteApps)
 	deleteChannels := cmd.NewCmd("channels").
@@ -36,7 +36,6 @@ func NewDeleteCmd() *cobra.Command {
 		WithAliases("t").
 		WithCommonFlags().
 		MinimumArgs(1, deleteTypes)
-
 	deleteAlias := cmd.NewCmd("alias").
 		WithDescription("Delete alias from scope").
 		WithExample("Delete alias from default scope", "delete alias <aliaskey>").
@@ -46,6 +45,7 @@ func NewDeleteCmd() *cobra.Command {
 		MinimumArgs(1, deleteAlias)
 
 	return cmd.NewCmd("delete").
+		WithCommonFlags().
 		WithDescription("Delete component of object type").
 		WithLongDescription("Delete takes a component type (apps | channels | types | alias) its scope and name, and deletes it from the cluster").
 		WithExample("deletes app", "delete apps <app_name>").
@@ -63,7 +63,6 @@ func NewDeleteCmd() *cobra.Command {
 func deleteApps(_ context.Context, args []string) error {
 	client := cliutils.GetCliClient()
 	out := cliutils.GetCliOutput()
-
 	scope, err := cliutils.GetScope()
 	if err != nil {
 		return err
@@ -72,7 +71,7 @@ func deleteApps(_ context.Context, args []string) error {
 	for _, arg := range args {
 		if !utils.IsValidScope(arg) {
 			fmt.Fprint(out, "invalid args\n")
-			return ierrors.NewError().Message("Invalid args").BadRequest().Build()
+			return ierrors.NewError().Message("invalid args").BadRequest().Build()
 		}
 		path, _ := utils.JoinScopes(scope, arg)
 

--- a/cmd/insprctl/cli/delete_test.go
+++ b/cmd/insprctl/cli/delete_test.go
@@ -602,7 +602,9 @@ func Test_deleteAlias(t *testing.T) {
 		}
 
 		fmt.Println(scope)
-		if scope != "appParent" || data.Key != "alias_name" {
+		if (scope != "appParent" && scope != "") ||
+			(data.Key != "alias.name" && data.Key != "appParent.alias.name") {
+
 			rest.ERROR(w, ierrors.NewError().Message("error test").Build())
 			return
 		}
@@ -618,19 +620,19 @@ func Test_deleteAlias(t *testing.T) {
 	}{
 		{
 			name:           "Should delete the alias and return the diff",
-			flagsAndArgs:   []string{"al", "appParent.alias_name"},
+			flagsAndArgs:   []string{"al", "appParent.alias.name"},
 			handlerFunc:    handler,
 			expectedOutput: bufResp.String(),
 		},
 		{
 			name:           "Invalid scope flag, should not print",
-			flagsAndArgs:   []string{"al", "appParent.alias_name", "--scope", "invalid..scope"},
+			flagsAndArgs:   []string{"al", "appParent.alias.name", "--scope", "invalid..scope"},
 			handlerFunc:    handler,
 			expectedOutput: "",
 		},
 		{
 			name:           "Valid scope flag",
-			flagsAndArgs:   []string{"al", "alias_name", "--scope", "appParent"},
+			flagsAndArgs:   []string{"al", "alias.name", "--scope", "appParent"},
 			handlerFunc:    handler,
 			expectedOutput: bufResp.String(),
 		},
@@ -655,6 +657,7 @@ func Test_deleteAlias(t *testing.T) {
 			defer server.Close()
 
 			cmd.Execute()
+
 			got := buf.String()
 
 			if !reflect.DeepEqual(got, tt.expectedOutput) {

--- a/cmd/insprd/memory/fake/mem_manager.go
+++ b/cmd/insprd/memory/fake/mem_manager.go
@@ -61,7 +61,7 @@ func MockMemoryManager(failErr error) memory.Manager {
 	}
 }
 
-// Root mocks a root getter interface
+// Tree mocks a root getter interface
 func (mm *MemManager) Tree() memory.GetInterface {
 	return (*LookupMemManager)(mm)
 }

--- a/cmd/insprd/memory/fake/mem_manager.go
+++ b/cmd/insprd/memory/fake/mem_manager.go
@@ -62,7 +62,7 @@ func MockMemoryManager(failErr error) memory.Manager {
 }
 
 // Root mocks a root getter interface
-func (mm *MemManager) Root() memory.GetInterface {
+func (mm *MemManager) Tree() memory.GetInterface {
 	return (*LookupMemManager)(mm)
 }
 

--- a/cmd/insprd/memory/interface.go
+++ b/cmd/insprd/memory/interface.go
@@ -79,7 +79,7 @@ type Manager interface {
 	Channels() ChannelMemory
 	Types() TypeMemory
 	Alias() AliasMemory
-	Root() GetInterface
+	Tree() GetInterface
 }
 
 // GetInterface is an interface to get components from memory

--- a/cmd/insprd/memory/tree/alias.go
+++ b/cmd/insprd/memory/tree/alias.go
@@ -199,16 +199,16 @@ func (amm *AliasMemoryManager) Delete(scope, aliasKey string) error {
 	return nil
 }
 
-// AliasTreeGetter returns a getter that gets alias from the root structure of the app, without the current changes.
+// AliasPermTreeGetter returns a getter that gets alias from the root structure of the app, without the current changes.
 // The getter does not allow changes in the structure, just visualization.
-type AliasTreeGetter struct {
+type AliasPermTreeGetter struct {
 }
 
 // Get receives a scope and a alias key. The scope defines
 // the path to an App. If this App has a pointer to a alias that has the
 // same key as the key passed as an argument, the pointer to that alias is returned
 // This method is used to get the structure as it is in the cluster, before any modifications.
-func (amm *AliasTreeGetter) Get(scope, aliasKey string) (*meta.Alias, error) {
+func (amm *AliasPermTreeGetter) Get(scope, aliasKey string) (*meta.Alias, error) {
 	logger.Info("trying to get an Alias (Root Getter)",
 		zap.String("alias", aliasKey),
 		zap.String("scope", scope))

--- a/cmd/insprd/memory/tree/alias.go
+++ b/cmd/insprd/memory/tree/alias.go
@@ -199,16 +199,16 @@ func (amm *AliasMemoryManager) Delete(scope, aliasKey string) error {
 	return nil
 }
 
-// AliasRootGetter returns a getter that gets alias from the root structure of the app, without the current changes.
+// AliasTreeGetter returns a getter that gets alias from the root structure of the app, without the current changes.
 // The getter does not allow changes in the structure, just visualization.
-type AliasRootGetter struct {
+type AliasTreeGetter struct {
 }
 
 // Get receives a scope and a alias key. The scope defines
 // the path to an App. If this App has a pointer to a alias that has the
 // same key as the key passed as an argument, the pointer to that alias is returned
 // This method is used to get the structure as it is in the cluster, before any modifications.
-func (amm *AliasRootGetter) Get(scope, aliasKey string) (*meta.Alias, error) {
+func (amm *AliasTreeGetter) Get(scope, aliasKey string) (*meta.Alias, error) {
 	logger.Info("trying to get an Alias (Root Getter)",
 		zap.String("alias", aliasKey),
 		zap.String("scope", scope))

--- a/cmd/insprd/memory/tree/channel.go
+++ b/cmd/insprd/memory/tree/channel.go
@@ -229,16 +229,16 @@ func (chh *ChannelMemoryManager) Update(scope string, ch *meta.Channel) error {
 	return nil
 }
 
-// ChannelTreeGetter returns a getter that gets channels from the root structure of the app, without the current changes.
+// ChannelPermTreeGetter returns a getter that gets channels from the root structure of the app, without the current changes.
 // The getter does not allow changes in the structure, just visualization.
-type ChannelTreeGetter struct {
+type ChannelPermTreeGetter struct {
 }
 
 // Get receives a query string (format = 'x.y.z') and iterates through the
 // memory tree until it finds the Channel which name is equal to the last query element.
 // If the specified Channel is found, it is returned. Otherwise, returns an error.
 // This method is used to get the structure as it is in the cluster, before any modifications.
-func (cmm *ChannelTreeGetter) Get(scope, name string) (*meta.Channel, error) {
+func (cmm *ChannelPermTreeGetter) Get(scope, name string) (*meta.Channel, error) {
 	logger.Info("trying to get a Channel (Root Getter)",
 		zap.String("channel", name),
 		zap.String("scope", scope))

--- a/cmd/insprd/memory/tree/channel.go
+++ b/cmd/insprd/memory/tree/channel.go
@@ -229,16 +229,16 @@ func (chh *ChannelMemoryManager) Update(scope string, ch *meta.Channel) error {
 	return nil
 }
 
-// ChannelRootGetter returns a getter that gets channels from the root structure of the app, without the current changes.
+// ChannelTreeGetter returns a getter that gets channels from the root structure of the app, without the current changes.
 // The getter does not allow changes in the structure, just visualization.
-type ChannelRootGetter struct {
+type ChannelTreeGetter struct {
 }
 
 // Get receives a query string (format = 'x.y.z') and iterates through the
 // memory tree until it finds the Channel which name is equal to the last query element.
 // If the specified Channel is found, it is returned. Otherwise, returns an error.
 // This method is used to get the structure as it is in the cluster, before any modifications.
-func (cmm *ChannelRootGetter) Get(scope, name string) (*meta.Channel, error) {
+func (cmm *ChannelTreeGetter) Get(scope, name string) (*meta.Channel, error) {
 	logger.Info("trying to get a Channel (Root Getter)",
 		zap.String("channel", name),
 		zap.String("scope", scope))

--- a/cmd/insprd/memory/tree/channel.go
+++ b/cmd/insprd/memory/tree/channel.go
@@ -30,7 +30,7 @@ func (chh *ChannelMemoryManager) Get(scope, name string) (*meta.Channel, error) 
 		zap.String("channel", name),
 		zap.String("scope", scope))
 
-	parentApp, err := GetTreeMemory().Apps().Get(scope)
+	parentApp, err := chh.Apps().Get(scope)
 	if err != nil {
 		newError := ierrors.
 			NewError().
@@ -86,7 +86,7 @@ func (chh *ChannelMemoryManager) Create(scope string, ch *meta.Channel) error {
 	}
 
 	logger.Debug("getting Channel parent dApp")
-	parentApp, err := GetTreeMemory().Apps().Get(scope)
+	parentApp, err := chh.Apps().Get(scope)
 	if err != nil {
 		newError := ierrors.NewError().InnerError(err).InvalidChannel().
 			Message("couldn't create channel %v : %v", ch.Meta.Name, err.Error()).
@@ -163,7 +163,7 @@ func (chh *ChannelMemoryManager) Delete(scope, name string) error {
 			Build()
 	}
 
-	parentApp, _ := GetTreeMemory().Apps().Get(scope)
+	parentApp, _ := chh.Apps().Get(scope)
 
 	insprType := parentApp.Spec.Types[channel.Spec.Type]
 
@@ -209,7 +209,7 @@ func (chh *ChannelMemoryManager) Update(scope string, ch *meta.Channel) error {
 	ch.ConnectedAliases = oldCh.ConnectedAliases
 	ch.Meta.UUID = oldCh.Meta.UUID
 
-	parentApp, _ := GetTreeMemory().Apps().Get(scope)
+	parentApp, _ := chh.Apps().Get(scope)
 
 	logger.Debug("validating new Channel structure")
 
@@ -238,12 +238,12 @@ type ChannelRootGetter struct {
 // memory tree until it finds the Channel which name is equal to the last query element.
 // If the specified Channel is found, it is returned. Otherwise, returns an error.
 // This method is used to get the structure as it is in the cluster, before any modifications.
-func (amm *ChannelRootGetter) Get(scope, name string) (*meta.Channel, error) {
+func (cmm *ChannelRootGetter) Get(scope, name string) (*meta.Channel, error) {
 	logger.Info("trying to get a Channel (Root Getter)",
 		zap.String("channel", name),
 		zap.String("scope", scope))
 
-	parentApp, err := GetTreeMemory().Root().Apps().Get(scope)
+	parentApp, err := GetTreeMemory().Tree().Apps().Get(scope)
 	if err != nil {
 		newError := ierrors.
 			NewError().

--- a/cmd/insprd/memory/tree/dapp.go
+++ b/cmd/insprd/memory/tree/dapp.go
@@ -183,9 +183,9 @@ func (amm *AppMemoryManager) Update(query string, app *meta.App) error {
 	return nil
 }
 
-// AppRootGetter returns a getter that gets apps from the root structure of the app, without the current changes.
+// AppTreeGetter returns a getter that gets apps from the root structure of the app, without the current changes.
 // The getter does not allow changes in the structure, just visualization.
-type AppRootGetter struct {
+type AppTreeGetter struct {
 	tree *meta.App
 }
 
@@ -194,7 +194,7 @@ type AppRootGetter struct {
 // The tree root dApp is returned if the query string is an empty string.
 // If the specified dApp is found, it is returned. Otherwise, returns an error.
 // This method is used to get the structure as it is in the cluster, before any modifications.
-func (amm *AppRootGetter) Get(query string) (*meta.App, error) {
+func (amm *AppTreeGetter) Get(query string) (*meta.App, error) {
 	logger.Info("trying to get a dApp (Root Getter)", zap.String("dApp", query))
 
 	if query == "" {

--- a/cmd/insprd/memory/tree/dapp.go
+++ b/cmd/insprd/memory/tree/dapp.go
@@ -183,9 +183,9 @@ func (amm *AppMemoryManager) Update(query string, app *meta.App) error {
 	return nil
 }
 
-// AppTreeGetter returns a getter that gets apps from the root structure of the app, without the current changes.
+// AppPermTreeGetter returns a getter that gets apps from the root structure of the app, without the current changes.
 // The getter does not allow changes in the structure, just visualization.
-type AppTreeGetter struct {
+type AppPermTreeGetter struct {
 	tree *meta.App
 }
 
@@ -194,7 +194,7 @@ type AppTreeGetter struct {
 // The tree root dApp is returned if the query string is an empty string.
 // If the specified dApp is found, it is returned. Otherwise, returns an error.
 // This method is used to get the structure as it is in the cluster, before any modifications.
-func (amm *AppTreeGetter) Get(query string) (*meta.App, error) {
+func (amm *AppPermTreeGetter) Get(query string) (*meta.App, error) {
 	logger.Info("trying to get a dApp (Root Getter)", zap.String("dApp", query))
 
 	if query == "" {

--- a/cmd/insprd/memory/tree/dapp_utils.go
+++ b/cmd/insprd/memory/tree/dapp_utils.go
@@ -215,7 +215,7 @@ func (amm *AppMemoryManager) connectAppBoundary(app *meta.App) error {
 func (amm *AppMemoryManager) updateUUID(app *meta.App, parentStr string) {
 	app.Meta.Parent = parentStr
 	query, _ := metautils.JoinScopes(parentStr, app.Meta.Name)
-	oldApp, err := amm.Root().Apps().Get(query)
+	oldApp, err := amm.Tree().Apps().Get(query)
 	if err == nil {
 		app.Meta.UUID = oldApp.Meta.UUID
 		for chName, ch := range app.Spec.Channels {

--- a/cmd/insprd/memory/tree/manager.go
+++ b/cmd/insprd/memory/tree/manager.go
@@ -86,36 +86,36 @@ func (mm *MemoryManager) GetTransactionChanges() (diff.Changelog, error) {
 	return cl, err
 }
 
-// RootGetter is a structure that gets components from the root, without the current changes.
-type RootGetter struct {
+// TreeGetter is a structure that gets components from the root, without the current changes.
+type TreeGetter struct {
 	tree *meta.App
 }
 
 // Apps returns a getter for apps on the root.
-func (t *RootGetter) Apps() memory.AppGetInterface {
-	return &AppRootGetter{
+func (t *TreeGetter) Apps() memory.AppGetInterface {
+	return &AppTreeGetter{
 		tree: t.tree,
 	}
 }
 
 // Channels returns a getter for channels on the root.
-func (t *RootGetter) Channels() memory.ChannelGetInterface {
-	return &ChannelRootGetter{}
+func (t *TreeGetter) Channels() memory.ChannelGetInterface {
+	return &ChannelTreeGetter{}
 }
 
 // Types returns a getter for Types on the root
-func (t *RootGetter) Types() memory.TypeGetInterface {
-	return &TypeRootGetter{}
+func (t *TreeGetter) Types() memory.TypeGetInterface {
+	return &TypeTreeGetter{}
 }
 
 // Alias returns a getter for alias on the root
-func (t *RootGetter) Alias() memory.AliasGetInterface {
-	return &AliasRootGetter{}
+func (t *TreeGetter) Alias() memory.AliasGetInterface {
+	return &AliasTreeGetter{}
 }
 
 // Tree returns a getter for objects on the tree without the current changes.
 func (mm *MemoryManager) Tree() memory.GetInterface {
-	return &RootGetter{
+	return &TreeGetter{
 		tree: mm.tree,
 	}
 }

--- a/cmd/insprd/memory/tree/manager.go
+++ b/cmd/insprd/memory/tree/manager.go
@@ -113,8 +113,8 @@ func (t *RootGetter) Alias() memory.AliasGetInterface {
 	return &AliasRootGetter{}
 }
 
-// Root returns a getter for objects on the root of the tree, without the current changes.
-func (mm *MemoryManager) Root() memory.GetInterface {
+// Root returns a getter for objects on the tree without the current changes.
+func (mm *MemoryManager) Tree() memory.GetInterface {
 	return &RootGetter{
 		tree: mm.tree,
 	}

--- a/cmd/insprd/memory/tree/manager.go
+++ b/cmd/insprd/memory/tree/manager.go
@@ -113,7 +113,7 @@ func (t *RootGetter) Alias() memory.AliasGetInterface {
 	return &AliasRootGetter{}
 }
 
-// Root returns a getter for objects on the tree without the current changes.
+// Tree returns a getter for objects on the tree without the current changes.
 func (mm *MemoryManager) Tree() memory.GetInterface {
 	return &RootGetter{
 		tree: mm.tree,

--- a/cmd/insprd/memory/tree/manager.go
+++ b/cmd/insprd/memory/tree/manager.go
@@ -86,36 +86,36 @@ func (mm *MemoryManager) GetTransactionChanges() (diff.Changelog, error) {
 	return cl, err
 }
 
-// TreeGetter is a structure that gets components from the root, without the current changes.
-type TreeGetter struct {
+// PermTreeGetter is a structure that gets components from the root, without the current changes.
+type PermTreeGetter struct {
 	tree *meta.App
 }
 
 // Apps returns a getter for apps on the root.
-func (t *TreeGetter) Apps() memory.AppGetInterface {
-	return &AppTreeGetter{
+func (t *PermTreeGetter) Apps() memory.AppGetInterface {
+	return &AppPermTreeGetter{
 		tree: t.tree,
 	}
 }
 
 // Channels returns a getter for channels on the root.
-func (t *TreeGetter) Channels() memory.ChannelGetInterface {
-	return &ChannelTreeGetter{}
+func (t *PermTreeGetter) Channels() memory.ChannelGetInterface {
+	return &ChannelPermTreeGetter{}
 }
 
 // Types returns a getter for Types on the root
-func (t *TreeGetter) Types() memory.TypeGetInterface {
-	return &TypeTreeGetter{}
+func (t *PermTreeGetter) Types() memory.TypeGetInterface {
+	return &TypePermTreeGetter{}
 }
 
 // Alias returns a getter for alias on the root
-func (t *TreeGetter) Alias() memory.AliasGetInterface {
-	return &AliasTreeGetter{}
+func (t *PermTreeGetter) Alias() memory.AliasGetInterface {
+	return &AliasPermTreeGetter{}
 }
 
 // Tree returns a getter for objects on the tree without the current changes.
 func (mm *MemoryManager) Tree() memory.GetInterface {
-	return &TreeGetter{
+	return &PermTreeGetter{
 		tree: mm.tree,
 	}
 }

--- a/cmd/insprd/memory/tree/mock_manager.go
+++ b/cmd/insprd/memory/tree/mock_manager.go
@@ -68,7 +68,7 @@ func (tmm *MockManager) GetTransactionChanges() (diff.Changelog, error) {
 
 // Tree mock interface structure
 func (tmm *MockManager) Tree() memory.GetInterface {
-	return &RootGetter{
+	return &TreeGetter{
 		tmm.root,
 	}
 }

--- a/cmd/insprd/memory/tree/mock_manager.go
+++ b/cmd/insprd/memory/tree/mock_manager.go
@@ -68,7 +68,7 @@ func (tmm *MockManager) GetTransactionChanges() (diff.Changelog, error) {
 
 // Tree mock interface structure
 func (tmm *MockManager) Tree() memory.GetInterface {
-	return &TreeGetter{
+	return &PermTreeGetter{
 		tmm.root,
 	}
 }

--- a/cmd/insprd/memory/tree/mock_manager.go
+++ b/cmd/insprd/memory/tree/mock_manager.go
@@ -67,7 +67,7 @@ func (tmm *MockManager) GetTransactionChanges() (diff.Changelog, error) {
 }
 
 // Root mock interface structure
-func (tmm *MockManager) Root() memory.GetInterface {
+func (tmm *MockManager) Tree() memory.GetInterface {
 	return &RootGetter{
 		tmm.root,
 	}

--- a/cmd/insprd/memory/tree/mock_manager.go
+++ b/cmd/insprd/memory/tree/mock_manager.go
@@ -66,7 +66,7 @@ func (tmm *MockManager) GetTransactionChanges() (diff.Changelog, error) {
 	return diff.Changelog{}, nil
 }
 
-// Root mock interface structure
+// Tree mock interface structure
 func (tmm *MockManager) Tree() memory.GetInterface {
 	return &RootGetter{
 		tmm.root,

--- a/cmd/insprd/memory/tree/types.go
+++ b/cmd/insprd/memory/tree/types.go
@@ -181,7 +181,7 @@ func (trg *TypeRootGetter) Get(scope, name string) (*meta.Type, error) {
 		zap.String("type", name),
 		zap.String("scope", scope))
 
-	parentApp, err := GetTreeMemory().Root().Apps().Get(scope)
+	parentApp, err := GetTreeMemory().Tree().Apps().Get(scope)
 	if err != nil {
 		return nil, ierrors.
 			NewError().

--- a/cmd/insprd/memory/tree/types.go
+++ b/cmd/insprd/memory/tree/types.go
@@ -168,15 +168,15 @@ func (tmm *TypeMemoryManager) Update(scope string, insprType *meta.Type) error {
 	return nil
 }
 
-// TypeRootGetter returns a getter that gets Types from the root structure of the app, without the current changes.
+// TypeTreeGetter returns a getter that gets Types from the root structure of the app, without the current changes.
 // The getter does not allow changes in the structure, just visualization.
-type TypeRootGetter struct{}
+type TypeTreeGetter struct{}
 
 // Get receives a query string (format = 'x.y.z') and iterates through the
 // memory tree until it finds the Type which name is equal to the last query element.
 // If the specified Type is found, it is returned. Otherwise, returns an error.
 // This method is used to get the structure as it is in the cluster, before any modifications.
-func (trg *TypeRootGetter) Get(scope, name string) (*meta.Type, error) {
+func (trg *TypeTreeGetter) Get(scope, name string) (*meta.Type, error) {
 	logger.Info("trying to get a Type (Root Getter)",
 		zap.String("type", name),
 		zap.String("scope", scope))

--- a/cmd/insprd/memory/tree/types.go
+++ b/cmd/insprd/memory/tree/types.go
@@ -168,15 +168,15 @@ func (tmm *TypeMemoryManager) Update(scope string, insprType *meta.Type) error {
 	return nil
 }
 
-// TypeTreeGetter returns a getter that gets Types from the root structure of the app, without the current changes.
+// TypePermTreeGetter returns a getter that gets Types from the root structure of the app, without the current changes.
 // The getter does not allow changes in the structure, just visualization.
-type TypeTreeGetter struct{}
+type TypePermTreeGetter struct{}
 
 // Get receives a query string (format = 'x.y.z') and iterates through the
 // memory tree until it finds the Type which name is equal to the last query element.
 // If the specified Type is found, it is returned. Otherwise, returns an error.
 // This method is used to get the structure as it is in the cluster, before any modifications.
-func (trg *TypeTreeGetter) Get(scope, name string) (*meta.Type, error) {
+func (trg *TypePermTreeGetter) Get(scope, name string) (*meta.Type, error) {
 	logger.Info("trying to get a Type (Root Getter)",
 		zap.String("type", name),
 		zap.String("scope", scope))

--- a/cmd/insprd/operators/channel.go
+++ b/cmd/insprd/operators/channel.go
@@ -2,7 +2,6 @@ package operators
 
 import (
 	"context"
-	"fmt"
 	"reflect"
 
 	"inspr.dev/inspr/cmd/insprd/memory"
@@ -120,11 +119,9 @@ func (g GenOp) Update(ctx context.Context, scope string, channel *meta.Channel) 
 
 //Delete executes Delete method of correct operator given the desired channel's broker
 func (g GenOp) Delete(ctx context.Context, scope, name string) error {
-	fmt.Println("ABLUBLEBLEBLABLUBLABLE")
 	op, err := g.getOperator(scope, name, true)
 	if err != nil {
 		return err
 	}
-	fmt.Println("XABLABLEXABLWXABLU")
 	return op.Delete(ctx, scope, name)
 }

--- a/cmd/insprd/operators/channel.go
+++ b/cmd/insprd/operators/channel.go
@@ -2,6 +2,7 @@ package operators
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 
 	"inspr.dev/inspr/cmd/insprd/memory"
@@ -35,8 +36,24 @@ func NewGeneralOperator(brokers brokers.Manager, memory memory.Manager) *GenOp {
 	}
 }
 
-func (g GenOp) getOperator(scope, name string) (ChannelOperatorInterface, error) {
-	channel, _ := g.memory.Channels().Get(scope, name)
+func (g GenOp) getOperator(scope, name string, deleteCmd bool) (ChannelOperatorInterface, error) {
+	var channel *meta.Channel
+	var err error
+
+	// delete should get it's channel information from the unaltered tree,
+	// otherwise the channel wouldnt be found
+	if deleteCmd {
+		channel, err = g.memory.Tree().Channels().Get(scope, name)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		channel, err = g.memory.Channels().Get(scope, name)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	broker := channel.Spec.SelectedBroker
 
 	config, err := g.brokers.Configs(broker)
@@ -76,7 +93,7 @@ func (g GenOp) setOperator(config metabrokers.BrokerConfiguration) error {
 
 //Get executes Get method of correct operator given the desired channel's broker
 func (g GenOp) Get(ctx context.Context, scope, name string) (*meta.Channel, error) {
-	op, err := g.getOperator(scope, name)
+	op, err := g.getOperator(scope, name, false)
 	if err != nil {
 		return nil, err
 	}
@@ -85,7 +102,7 @@ func (g GenOp) Get(ctx context.Context, scope, name string) (*meta.Channel, erro
 
 //Create executes Create method of correct operator given the desired channel's broker
 func (g GenOp) Create(ctx context.Context, scope string, channel *meta.Channel) error {
-	op, err := g.getOperator(scope, channel.Meta.Name)
+	op, err := g.getOperator(scope, channel.Meta.Name, false)
 	if err != nil {
 		return err
 	}
@@ -94,7 +111,7 @@ func (g GenOp) Create(ctx context.Context, scope string, channel *meta.Channel) 
 
 //Update executes Update method of correct operator given the desired channel's broker
 func (g GenOp) Update(ctx context.Context, scope string, channel *meta.Channel) error {
-	op, err := g.getOperator(scope, channel.Meta.Name)
+	op, err := g.getOperator(scope, channel.Meta.Name, false)
 	if err != nil {
 		return err
 	}
@@ -103,9 +120,11 @@ func (g GenOp) Update(ctx context.Context, scope string, channel *meta.Channel) 
 
 //Delete executes Delete method of correct operator given the desired channel's broker
 func (g GenOp) Delete(ctx context.Context, scope, name string) error {
-	op, err := g.getOperator(scope, name)
+	fmt.Println("ABLUBLEBLEBLABLUBLABLE")
+	op, err := g.getOperator(scope, name, true)
 	if err != nil {
 		return err
 	}
+	fmt.Println("XABLABLEXABLWXABLU")
 	return op.Delete(ctx, scope, name)
 }

--- a/cmd/insprd/operators/kafka/client.go
+++ b/cmd/insprd/operators/kafka/client.go
@@ -60,7 +60,7 @@ func NewOperator(mem memory.Manager, config sidecars.KafkaConfig) (*ChannelOpera
 
 // Get gets a channel from kafka
 func (c *ChannelOperator) Get(ctx context.Context, context string, name string) (*meta.Channel, error) {
-	channel, _ := c.mem.Root().Channels().Get(context, name)
+	channel, _ := c.mem.Tree().Channels().Get(context, name)
 	logger.Info("trying to get Channel from Kafka Topic",
 		zap.String("channel", name),
 		zap.String("context", context))
@@ -132,7 +132,7 @@ func (c *ChannelOperator) Update(ctx context.Context, context string, channel *m
 
 // Delete deletes a channel from kafka
 func (c *ChannelOperator) Delete(ctx context.Context, context string, name string) error {
-	channel, _ := c.mem.Root().Channels().Get(context, name)
+	channel, _ := c.mem.Tree().Channels().Get(context, name)
 	topics := []string{toTopic(channel)}
 	logger.Info("trying to delete a Channel from Kafka Topics",
 		zap.String("channel", name),

--- a/cmd/insprd/operators/nodes/node_operator.go
+++ b/cmd/insprd/operators/nodes/node_operator.go
@@ -87,7 +87,7 @@ func (no *NodeOperator) DeleteNode(ctx context.Context, nodeContext string, node
 
 	logger.Debug("getting name of the k8s deployment to be deleted")
 	scope, _ := utils.JoinScopes(nodeContext, nodeName)
-	app, _ := no.memory.Root().Apps().Get(scope)
+	app, _ := no.memory.Tree().Apps().Get(scope)
 
 	logger.Info("deploying a Node structure in k8s",
 		zap.Any("node", app))

--- a/pkg/api/handlers/alias_handler.go
+++ b/pkg/api/handlers/alias_handler.go
@@ -106,7 +106,7 @@ func (ah *AliasHandler) HandleGet() rest.Handler {
 		logger.Debug("initiating Alias get transaction")
 		ah.Memory.InitTransaction()
 
-		app, err := ah.Memory.Root().Alias().Get(scope, data.Key)
+		app, err := ah.Memory.Tree().Alias().Get(scope, data.Key)
 		if err != nil {
 			logger.Error("unable to get Alias",
 				zap.String("alias key", data.Key),

--- a/pkg/api/handlers/app_handler.go
+++ b/pkg/api/handlers/app_handler.go
@@ -110,7 +110,7 @@ func (ah *AppHandler) HandleGet() rest.Handler {
 		logger.Debug("initiating dApp get transaction")
 		ah.Memory.InitTransaction()
 
-		app, err := ah.Memory.Root().Apps().Get(scope)
+		app, err := ah.Memory.Tree().Apps().Get(scope)
 		if err != nil {
 			logger.Error("unable to get dApp",
 				zap.String("dApp query", scope),
@@ -238,10 +238,10 @@ func (ah *AppHandler) HandleDelete() rest.Handler {
 				return
 			}
 
-			logger.Info("committing Channel create changes")
+			logger.Info("committing Channel delete changes")
 			defer ah.Memory.Commit()
 		} else {
-			logger.Info("cancelling Channel create changes")
+			logger.Info("cancelling Channel delete changes")
 			defer ah.Memory.Cancel()
 		}
 

--- a/pkg/api/handlers/channel_handler.go
+++ b/pkg/api/handlers/channel_handler.go
@@ -103,7 +103,7 @@ func (ch *ChannelHandler) HandleGet() rest.Handler {
 		logger.Debug("initiating Channel get transaction")
 		ch.Memory.InitTransaction()
 
-		channel, err := ch.Memory.Root().Channels().Get(scope, data.ChName)
+		channel, err := ch.Memory.Tree().Channels().Get(scope, data.ChName)
 		if err != nil {
 			logger.Error("unable to get Channel",
 				zap.String("channel", data.ChName),
@@ -213,7 +213,7 @@ func (ch *ChannelHandler) HandleDelete() rest.Handler {
 			return
 		}
 
-		changes, err := ch.Memory.Channels().GetTransactionChanges()
+		changes, err := ch.Memory.GetTransactionChanges()
 		if err != nil {
 			logger.Error("unable to get Channel delete request changes",
 				zap.Any("error", err))
@@ -233,10 +233,10 @@ func (ch *ChannelHandler) HandleDelete() rest.Handler {
 				return
 			}
 
-			logger.Info("committing Channel create changes")
+			logger.Info("committing Channel delete changes")
 			defer ch.Memory.Commit()
 		} else {
-			logger.Info("cancelling Channel create changes")
+			logger.Info("cancelling Channel delete changes")
 			defer ch.Memory.Cancel()
 		}
 

--- a/pkg/api/handlers/reactions.go
+++ b/pkg/api/handlers/reactions.go
@@ -11,7 +11,7 @@ import (
 var createdNodes func(handler *Handler) diff.ChangeReaction = func(handler *Handler) diff.ChangeReaction {
 	return diff.NewChangeReaction(
 		func(c diff.Change) bool {
-			_, errFrom := handler.Memory.Root().Apps().Get(c.Scope)
+			_, errFrom := handler.Memory.Tree().Apps().Get(c.Scope)
 			to, errTo := handler.Memory.Apps().Get(c.Scope)
 			return (errFrom != nil && errTo == nil && to.Spec.Node.Spec.Image != "")
 		},
@@ -60,7 +60,7 @@ var deletedApps func(handler *Handler) diff.DifferenceReaction = func(handler *H
 		},
 		func(scope string, d diff.Difference) error {
 			scope, _ = utils.JoinScopes(scope, d.Name)
-			app, err := handler.Memory.Root().Apps().Get(scope) // get the app definition from the cluster
+			app, err := handler.Memory.Tree().Apps().Get(scope) // get the app definition from the cluster
 			if err != nil {
 				return err
 			}
@@ -145,7 +145,7 @@ var updatedChannels func(handler *Handler) diff.DifferenceReaction = func(handle
 var updatedNodes func(handler *Handler) diff.ChangeReaction = func(handler *Handler) diff.ChangeReaction {
 	return diff.NewChangeReaction(
 		func(c diff.Change) bool {
-			from, _ := handler.Memory.Root().Apps().Get(c.Scope)
+			from, _ := handler.Memory.Tree().Apps().Get(c.Scope)
 			// if there is a change in a given scope and that scope is a node
 			return from != nil && from.Spec.Node.Spec.Image != ""
 		},

--- a/pkg/api/handlers/token_handler.go
+++ b/pkg/api/handlers/token_handler.go
@@ -27,7 +27,7 @@ func (h *Handler) ControllerRefreshHandler() rest.Handler {
 		// this is the path to the app
 		appQuery := string(received.RefreshToken)
 
-		app, err := h.Memory.Root().Apps().Get(appQuery)
+		app, err := h.Memory.Tree().Apps().Get(appQuery)
 		if err != nil {
 			log.Printf("err = %+v\n", err)
 			rest.ERROR(w, err)

--- a/pkg/api/handlers/type_handler.go
+++ b/pkg/api/handlers/type_handler.go
@@ -94,7 +94,7 @@ func (th *TypeHandler) HandleGet() rest.Handler {
 		logger.Debug("initiating Type get transaction")
 		th.Memory.InitTransaction()
 
-		insprType, err := th.Memory.Root().Types().Get(scope, data.TypeName)
+		insprType, err := th.Memory.Tree().Types().Get(scope, data.TypeName)
 		if err != nil {
 			logger.Error("unable to get Type",
 				zap.String("type-name", data.TypeName),

--- a/pkg/cmd/flags.go
+++ b/pkg/cmd/flags.go
@@ -51,7 +51,8 @@ var flagRegistry = []Flag{
 		Value:         &InsprOptions.DryRun,
 		DefValue:      false,
 		FlagAddMethod: "BoolVar",
-		DefinedOn:     []string{"apply"},
+		DefinedOn: []string{"apply", "delete", "apps", "channels",
+			"types", "alias"},
 	},
 	{
 		Name:      "token",


### PR DESCRIPTION
# Description

Kind: Bugfix
<!-- Specify the kind of the pull request, as in if it's a Bug fix, a Feature, a Story, a Tech Pendency, etc.
-->

Section: Channel operator, Tree memory and Insprd CLI
<!-- Section can be the specific folder or file refered by the pull request, like "pkg/ierrors", or a most wide section that comprehends multiple folders and files, like "Sidecar".
-->

Summary: When trying to `insprctl delete ch` multiple channels at once, an "invalid memory address" error was occurring and breaking Insprd. We figured that this was happening because the Channel Operator was trying to get the deleted channel's operator and, because the channel was deleted, it was hitting an invalid memory address.  
To solve this, the Channel Operator now retrieves it's channel from the `tree` structure, and not from the `root` (`root` works as an auxiliary Insprd tree memory in which the user operations are applied before actually making the real changes in the main memory structure `tree`).  
<!-- A quick description of what was changed, fixed or implemented (e.g. "Configured all Insprd routes to validate authentication")
-->

## Changelog

> Altered the Channel Operator when handling delete
> Fixed Insprd CLI's Alias delete command (and its tests)
> In the tree memory manager renamed method `Root()`, which returns the `tree`, to `Tree()`
> Updated Insprd CLI's cluster config command error messages

## Pay attention to

> The name change from `Root()` to `Tree()`. Everything was tested tho.
> There might be a better way to make the change that was done in the Channel Operator. Suggestions are welcome.
