### PR TITLE
Bug CORE-499 |  Unable to delete multi-layered dApps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,22 @@
 
 # Changelog
 
+### #90 Bug CORE-499 | Unable to delete multi-layered dApps
+- refactories:
+    - Added the usePermTree (bool) parameter in the ResolveBoundary function. If true, then use the unmodified app tree.
+    - Updated all uses of the ResolveBoundary function. In particular, in the convert file of package node the parameter usePermTree is set to true
+---
+
 ### #86 Story CORE-485 | minikube.md
 - features:
   - created the documentation on how to run insprd/uidp on minikube
 ---
+
 ### #85 Story CORE-464 | Multibroker documentation
 - features:
     - documentation for multibroker feature
 ---
+
 ### #84 Story CORE-480 | difference.md
 - features:
     - Updated `difference.md`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 # Changelog
 
 ### #90 Bug CORE-499 | Unable to delete multi-layered dApps
-- refactories:
+- refactors:
     - Added the usePermTree (bool) parameter in the ResolveBoundary function. If true, then use the unmodified app tree.
     - Updated all uses of the ResolveBoundary function. In particular, in the convert file of package node the parameter usePermTree is set to true
 ---

--- a/build/uidp_helm/values.yaml
+++ b/build/uidp_helm/values.yaml
@@ -41,7 +41,7 @@ secretRepository: gcr.io/insprlabs/uidp/redis/secret
 secret:
   privateKeyName: redisprivatekey
   adminPassword: "123456"
-  adminToken: eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2MjUyMjkzNTgsInBheWxvYWQiOnsidWlkIjoiIiwicGVybWlzc2lvbnMiOnsiIjpbImNyZWF0ZTp0b2tlbiJdfSwicmVmcmVzaCI6bnVsbCwicmVmcmVzaHVybCI6IiJ9fQ.g1PdN3adq5F_TyDZbOXfX0bkWre8-j-zmAMoFre1sYM9dmW5P1AqQ8EYMczP7VPQLlairzd5LGR2Q1fRb7d5bQ
+  adminToken: eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2MjU3NTY3OTgsInBheWxvYWQiOnsidWlkIjoiIiwicGVybWlzc2lvbnMiOnsiIjpbImNyZWF0ZTp0b2tlbiJdfSwicmVmcmVzaCI6bnVsbCwicmVmcmVzaHVybCI6IiJ9fQ.cg__oTdtBqh9N_qMluh2GhlU2R6HYifdbt7SmJ-HT-cRpSmlXSw1KLo8Jtb6gXcFaMCixtxTQZXHbOSZwhc0-w
     # set this admin token from a token that contains full power over the cluster
 
 statefulset:

--- a/cmd/insprd/memory/fake/dapp.go
+++ b/cmd/insprd/memory/fake/dapp.go
@@ -86,7 +86,7 @@ func (a *Apps) Update(scope string, app *meta.App, brokers *apimodels.BrokersDI)
 }
 
 // ResolveBoundary mock
-func (*Apps) ResolveBoundary(app *meta.App) (map[string]string, error) {
+func (*Apps) ResolveBoundary(app *meta.App, usePermTree bool) (map[string]string, error) {
 	ret := map[string]string{}
 	for _, ch := range app.Spec.Boundary.Input.Union(app.Spec.Boundary.Output) {
 		ret[ch] = ch

--- a/cmd/insprd/memory/tree/dapp_test.go
+++ b/cmd/insprd/memory/tree/dapp_test.go
@@ -2458,7 +2458,7 @@ func TestAppMemoryManager_ResolveBoundary(t *testing.T) {
 				tree: tt.fields.root,
 			}
 			amm := mem.Apps()
-			got, err := amm.ResolveBoundary(tt.args.app)
+			got, err := amm.ResolveBoundary(tt.args.app, false)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("AppMemoryManager.ResolveBoundary() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/cmd/insprd/memory/tree/dapp_utils.go
+++ b/cmd/insprd/memory/tree/dapp_utils.go
@@ -129,7 +129,7 @@ func (amm *AppMemoryManager) recursiveBoundaryValidation(app *meta.App) error {
 	merr := ierrors.MultiError{
 		Errors: []error{},
 	}
-	_, err := amm.ResolveBoundary(app)
+	_, err := amm.ResolveBoundary(app, false)
 	if err != nil {
 		merr.Add(ierrors.NewError().Message(err.Error()).Build())
 		return &merr

--- a/cmd/insprd/memory/tree/interface.go
+++ b/cmd/insprd/memory/tree/interface.go
@@ -31,7 +31,7 @@ type AppMemory interface {
 	Create(scope string, app *meta.App, brokers *apimodels.BrokersDI) error
 	Delete(query string) error
 	Update(query string, app *meta.App, brokers *apimodels.BrokersDI) error
-	ResolveBoundary(app *meta.App) (map[string]string, error)
+	ResolveBoundary(app *meta.App, usePermTree bool) (map[string]string, error)
 }
 
 // AppGetInterface is an interface to get apps from memory

--- a/cmd/insprd/memory/tree/mock_app.go
+++ b/cmd/insprd/memory/tree/mock_app.go
@@ -35,6 +35,6 @@ func (mock *MockAppManager) Update(scope string, app *meta.App, brokers *apimode
 }
 
 // ResolveBoundary Mock
-func (mock *MockAppManager) ResolveBoundary(app *meta.App) (map[string]string, error) {
+func (mock *MockAppManager) ResolveBoundary(app *meta.App, usePermTree bool) (map[string]string, error) {
 	return nil, nil
 }

--- a/cmd/insprd/operators/nodes/converter.go
+++ b/cmd/insprd/operators/nodes/converter.go
@@ -23,6 +23,8 @@ import (
 var lbsidecarPort int32
 
 func (no *NodeOperator) dappToService(app *meta.App) *kubeService {
+	logger.Info("constructing kube service")
+
 	temp, _ := strconv.Atoi(os.Getenv("INSPR_LBSIDECAR_PORT"))
 	lbsidecarPort = int32(temp)
 	appID := toAppID(app)
@@ -119,7 +121,7 @@ func (no *NodeOperator) getAllSidecarBrokers(app *meta.App) utils.StringArray {
 	output := app.Spec.Boundary.Output
 	channels := input.Union(output)
 
-	resolves, err := no.memory.Apps().ResolveBoundary(app)
+	resolves, err := no.memory.Apps().ResolveBoundary(app, true)
 	if err != nil {
 		logger.Error("unable to resolve Node boundaries",
 			zap.Any("boundaries", app.Spec.Boundary))
@@ -149,7 +151,7 @@ func (no *NodeOperator) withBoundary(app *meta.App) k8s.ContainerOption {
 		output := app.Spec.Boundary.Output
 		channels := input.Union(output)
 
-		resolves, err := no.memory.Apps().ResolveBoundary(app)
+		resolves, err := no.memory.Apps().ResolveBoundary(app, true)
 		if err != nil {
 			logger.Error("unable to resolve Node boundaries",
 				zap.Any("boundaries", app.Spec.Boundary))

--- a/cmd/insprd/operators/nodes/converter.go
+++ b/cmd/insprd/operators/nodes/converter.go
@@ -23,7 +23,7 @@ import (
 var lbsidecarPort int32
 
 func (no *NodeOperator) dappToService(app *meta.App) *kubeService {
-	logger.Info("constructing kube service")
+	logger.Info("creating kubernetes service")
 
 	temp, _ := strconv.Atoi(os.Getenv("INSPR_LBSIDECAR_PORT"))
 	lbsidecarPort = int32(temp)

--- a/cmd/insprd/operators/nodes/node_operator.go
+++ b/cmd/insprd/operators/nodes/node_operator.go
@@ -90,9 +90,14 @@ func (no *NodeOperator) DeleteNode(ctx context.Context, nodeContext string, node
 
 	logger.Debug("getting name of the k8s deployment to be deleted")
 	scope, _ := utils.JoinScopes(nodeContext, nodeName)
-	app, _ := no.memory.Perm().Apps().Get(scope)
+	app, err := no.memory.Perm().Apps().Get(scope)
+	if err != nil {
+		logger.Info("Error while getting app inside DeleteNode",
+			zap.String("scope", scope),
+		)
+	}
 
-	logger.Info("deploying a Node structure in k8s",
+	logger.Debug("deleting a Node structure in k8s",
 		zap.Any("node", app))
 
 	for _, applicable := range no.dappApplications(app) {

--- a/examples/pingpong_demo/README.md
+++ b/examples/pingpong_demo/README.md
@@ -15,7 +15,7 @@ Before running the Inspr CLI command to create the app in your cluster be sure t
 Also, this example uses Kafka as the Channels Message Broker, so it must be first installed in the cluster, and then you must install it on Insprd.  
 
 You can install Kafka in Insprd running the following command from within `/examples/pingpong_demo` folder:
-`insprctl cluster config kafka yamls/kafka.yaml`.
+`insprctl cluster config kafka yamls/kafkaConfig.yaml`.
 
 Now that everything is set and ready, run the following commands from within `/pingpong_demo` to apply the structures in defined in `/yamls` folder:
 ```

--- a/pkg/api/handlers/app_handler.go
+++ b/pkg/api/handlers/app_handler.go
@@ -223,7 +223,7 @@ func (ah *AppHandler) HandleDelete() rest.Handler {
 			return
 		}
 
-		logger.Debug("initiating dApp delete transaction")
+		logger.Info("initiating dApp delete transaction")
 		ah.Memory.Tree().InitTransaction()
 
 		err = ah.Memory.Tree().Apps().Delete(scope)
@@ -256,10 +256,10 @@ func (ah *AppHandler) HandleDelete() rest.Handler {
 				return
 			}
 
-			logger.Info("committing Channel delete changes")
+			logger.Debug("committing dApp delete changes")
 			defer ah.Memory.Tree().Commit()
 		} else {
-			logger.Info("cancelling Channel delete changes")
+			logger.Debug("cancelling dApp delete changes")
 			defer ah.Memory.Tree().Cancel()
 		}
 


### PR DESCRIPTION
# Description

Kind: Bug Fix

Section: dapp memory tree / node converter

Summary:

The error:
The function of the node package dAppToDeployment(app) uses the ResolveBoundary function of the tree app which in turn uses the function Get app (which is the Get that HAS the changes made to the tree). But it was expected to use the unmodified app tree.

The solution:
Added the usePermTree (bool) parameter in the ResolveBoundary function. If true, then use the unmodified app tree.

## Changelog

* Added the usePermTree (bool) parameter in the ResolveBoundary function. If true, then use the unmodified app tree.
* Updated all uses of this function. In particular, in the convert file of package node the parameter usePermTree is set to true.

