### PR TITLE
Tech CORE-490 | Channels envvars with broker

### DIFF
--- a/cmd/insprd/operators/nodes/converter.go
+++ b/cmd/insprd/operators/nodes/converter.go
@@ -203,7 +203,7 @@ func (no *NodeOperator) returnChannelBroker(channel, pathToResolvedChannel strin
 	if err != nil {
 		return ""
 	}
-	return fmt.Sprintf("%s_%s", channel, resolvedCh.Spec.SelectedBroker)
+	return fmt.Sprintf("%s@%s", channel, resolvedCh.Spec.SelectedBroker)
 }
 
 func (no *NodeOperator) toSecret(app *meta.App) *kubeSecret {

--- a/cmd/insprd/operators/nodes/converter_test.go
+++ b/cmd/insprd/operators/nodes/converter_test.go
@@ -182,7 +182,7 @@ func TestNodeOperator_withBoundary(t *testing.T) {
 				Env: []kubeCore.EnvVar{
 					{
 						Name:  "INSPR_INPUT_CHANNELS",
-						Value: "channel1_someBroker;channel2_someBroker",
+						Value: "channel1@someBroker;channel2@someBroker",
 					},
 					{
 						Name:  "INSPR_OUTPUT_CHANNELS",
@@ -242,7 +242,7 @@ func TestNodeOperator_withBoundary(t *testing.T) {
 				Env: []kubeCore.EnvVar{
 					{
 						Name:  "INSPR_OUTPUT_CHANNELS",
-						Value: "channel1_someBroker;channel2_someBroker",
+						Value: "channel1@someBroker;channel2@someBroker",
 					},
 					{
 						Name:  "INSPR_INPUT_CHANNELS",

--- a/cmd/sidecars/kafka/client/mock_kafka.go
+++ b/cmd/sidecars/kafka/client/mock_kafka.go
@@ -76,8 +76,8 @@ func (mc *MockConsumer) Close() (err error) {
 // createMockEnvVars - sets up the env values to be used in the tests functions
 // createMockEnvVars - sets up the env values to be used in the tests functions
 func createMockEnv() {
-	os.Setenv("INSPR_INPUT_CHANNELS", "ch1_someBroker;ch2_someBroker")
-	os.Setenv("INSPR_OUTPUT_CHANNELS", "ch1_someBroker;ch2_someBroker")
+	os.Setenv("INSPR_INPUT_CHANNELS", "ch1@someBroker;ch2@someBroker")
+	os.Setenv("INSPR_OUTPUT_CHANNELS", "ch1@someBroker;ch2@someBroker")
 	os.Setenv("INSPR_UNIX_SOCKET", "/addr/to/socket")
 	os.Setenv("INSPR_APP_SCOPE", "")
 	os.Setenv("INSPR_ENV", "random")

--- a/pkg/environment/environment_test.go
+++ b/pkg/environment/environment_test.go
@@ -8,8 +8,8 @@ import (
 
 func mockInsprEnvironment() *InsprEnvVars {
 	return &InsprEnvVars{
-		InputChannels:    "chan_someBroker;chan1_someBroker;chan2_someBroker;chan3_someBroker",
-		OutputChannels:   "chan_someBroker;chan1_someBroker;chan2_someBroker;chan3_someBroker",
+		InputChannels:    "chan@someBroker;chan1@someBroker;chan2@someBroker;chan3@someBroker",
+		OutputChannels:   "chan@someBroker;chan1@someBroker;chan2@someBroker;chan3@someBroker",
 		SidecarImage:     "mock_sidecar_image",
 		InsprAppContext:  "mock.dapp.context",
 		InsprEnvironment: "mock_env",
@@ -55,14 +55,14 @@ func Test_getEnv(t *testing.T) {
 			args: args{
 				name: "INSPR_INPUT_CHANNELS",
 			},
-			want: "chan_someBroker;chan1_someBroker;chan2_someBroker;chan3_someBroker",
+			want: "chan@someBroker;chan1@someBroker;chan2@someBroker;chan3@someBroker",
 		},
 		{
 			name: "Get output channel environment variable",
 			args: args{
 				name: "INSPR_OUTPUT_CHANNELS",
 			},
-			want: "chan_someBroker;chan1_someBroker;chan2_someBroker;chan3_someBroker",
+			want: "chan@someBroker;chan1@someBroker;chan2@someBroker;chan3@someBroker",
 		},
 		{
 			name: "Get unix socket environment variable",

--- a/pkg/environment/mocks.go
+++ b/pkg/environment/mocks.go
@@ -4,7 +4,7 @@ import "os"
 
 // SetMockEnv - sets the environment variables to specific values
 func SetMockEnv() {
-	channelsValues := "chan_someBroker;chan1_someBroker;chan2_someBroker;chan3_someBroker"
+	channelsValues := "chan@someBroker;chan1@someBroker;chan2@someBroker;chan3@someBroker"
 	os.Setenv("INSPR_LBSIDECAR_PORT", "8888")
 	os.Setenv("INSPR_INPUT_CHANNELS", channelsValues)
 	os.Setenv("INSPR_OUTPUT_CHANNELS", channelsValues)

--- a/pkg/environment/utils.go
+++ b/pkg/environment/utils.go
@@ -83,7 +83,7 @@ func getChannelData(channelList string) []brokers.ChannelBroker {
 	channelBrokers := utils.StringArray(strings.Split(channelList, ";"))
 	channels := []brokers.ChannelBroker{}
 	channelBrokers.Map(func(channel string) string {
-		data := strings.Split(channel, "_")
+		data := strings.Split(channel, "@")
 		channelData := brokers.ChannelBroker{
 			ChName: data[0],
 			Broker: data[1],

--- a/pkg/environment/utils_test.go
+++ b/pkg/environment/utils_test.go
@@ -84,7 +84,7 @@ func TestGetChannelBoundaryList(t *testing.T) {
 		{
 			name: "It should get all the channels in the InputChannels env",
 			fields: fields{
-				InputChannels:    "ch1_b;ch2_b;ch3_b;ch4_b",
+				InputChannels:    "ch1@b;ch2@b;ch3@b;ch4@b",
 				OutputChannels:   "",
 				UnixSocketAddr:   "",
 				InsprAppContext:  "",
@@ -187,7 +187,7 @@ func TestGetResolvedBoundaryChannelList(t *testing.T) {
 		{
 			name: "Returns resolved boundary",
 			args: args{
-				boundary: "ch1_b;ch2_b",
+				boundary: "ch1@b;ch2@b",
 			},
 			want: utils.StringArray{"channel1_resolved", "channel2_resolved"},
 		},
@@ -219,7 +219,7 @@ func TestGetResolvedChannel(t *testing.T) {
 			name: "Returns resolved channel",
 			args: args{
 				channel:   "ch1",
-				inputChan: "ch1_b;ch2_b",
+				inputChan: "ch1@b;ch2@b",
 			},
 			wantErr: false,
 			want:    "channel1_resolved",
@@ -228,7 +228,7 @@ func TestGetResolvedChannel(t *testing.T) {
 			name: "Invalid channel",
 			args: args{
 				channel:   "ch3",
-				inputChan: "ch1_b;ch2_b",
+				inputChan: "ch1@b;ch2@b",
 			},
 			wantErr: true,
 			want:    "",

--- a/pkg/sidecars/lbsidecar/handlers_test.go
+++ b/pkg/sidecars/lbsidecar/handlers_test.go
@@ -244,7 +244,7 @@ func TestServer_readMessageHandler(t *testing.T) {
 type randomStruct struct{}
 
 func createMockEnvVars() {
-	customEnvValues := "chan1_randBroker3;chan3_randBroker4;chan4_randBroker2;chan5_randBroker1;chan6_randBroker5"
+	customEnvValues := "chan1@randBroker3;chan3@randBroker4;chan4@randBroker2;chan5@randBroker1;chan6@randBroker5"
 	os.Setenv("INSPR_INPUT_CHANNELS", customEnvValues)
 	os.Setenv("INSPR_OUTPUT_CHANNELS", customEnvValues)
 

--- a/pkg/sidecars/server/handlers_test.go
+++ b/pkg/sidecars/server/handlers_test.go
@@ -22,7 +22,7 @@ import (
 
 // createMockEnvVars - sets up the env values to be used in the tests functions
 func createMockEnvVars() {
-	customEnvValues := "chan_someBroker;testing_someBroker;banana_someBroker"
+	customEnvValues := "chan@someBroker;testing@someBroker;banana@someBroker"
 	var unixSocketAddr = "/tmp/insprd.sock"
 	os.Setenv("INSPR_INPUT_CHANNELS", customEnvValues)
 	os.Setenv("INSPR_OUTPUT_CHANNELS", customEnvValues)


### PR DESCRIPTION
# Description

Kind:
Tech Pendency

Section:
Operators converter, environment utils.

Summary:
Change the separator from "_" to "@" for the channel brokers.

## Changelog

- features:
	- change the separator for the channel brokers. 
- test
        - fixed the tests that use channel's env variables   
