### PR TITLE
Story CORE-493 | Restart Policy for Nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 
 # Changelog
 
+### #98 Story CORE-493 | Restart Policy for Nodes
+- refactors:
+    - Deleted option/function of configuring restartPolicy of a deployment
+    - Deleted the tests of the function that changed the restart policy
+    - Added support for creating nodes with replicas
+---
+
 ### #96 Tech CORE-372 | Protect user password on inprov login #96
 - features:
     - developed new execution standard for login command

--- a/cmd/insprd/operators/nodes/converter.go
+++ b/cmd/insprd/operators/nodes/converter.go
@@ -76,6 +76,7 @@ func (no *NodeOperator) dAppToDeployment(app *meta.App) *kubeDeploy {
 			k8s.WithContainer(
 				append(scContainers, nodeContainer)...,
 			),
+			k8s.WithReplicas(app.Spec.Node.Spec.Replicas),
 		))
 }
 
@@ -146,7 +147,6 @@ func (no *NodeOperator) withBoundary(app *meta.App) k8s.ContainerOption {
 		return nil
 	}
 	return func(c *corev1.Container) {
-
 		input := app.Spec.Boundary.Input
 		output := app.Spec.Boundary.Output
 		channels := input.Union(output)

--- a/examples/pingpong_demo/yamls/nodes/ping.app.yaml
+++ b/examples/pingpong_demo/yamls/nodes/ping.app.yaml
@@ -7,7 +7,7 @@ meta:
 spec:
   node:
     spec:
-      replicas: 1
+      replicas: 3
       image: gcr.io/insprlabs/inspr/example/ping:latest
       environment:
         SUPER_SECRET_0001: "false"

--- a/pkg/meta/dapp.go
+++ b/pkg/meta/dapp.go
@@ -22,11 +22,12 @@ type SidecarPort struct {
 
 // NodeSpec represents a configuration for a node. The image represents the Docker image for the main container of the Node.
 type NodeSpec struct {
-	Ports       []NodePort           `yaml:"ports,omitempty" json:"ports,omitempty"`
-	Image       string               `yaml:"image,omitempty"  json:"image"`
-	Replicas    int                  `yaml:"replicas,omitempty" json:"replicas"`
-	Environment utils.EnvironmentMap `yaml:"environment,omitempty" json:"environment"`
-	SidecarPort SidecarPort          `yaml:"sidecarPort,omitempty" json:"sidecarPort"`
+	Ports         []NodePort           `yaml:"ports,omitempty" json:"ports,omitempty"`
+	Image         string               `yaml:"image,omitempty"  json:"image"`
+	Replicas      int                  `yaml:"replicas,omitempty" json:"replicas"`
+	RestartPolicy string               `yaml:"restartPolicy,omitempty" json:"restartPolicy"`
+	Environment   utils.EnvironmentMap `yaml:"environment,omitempty" json:"environment"`
+	SidecarPort   SidecarPort          `yaml:"sidecarPort,omitempty" json:"sidecarPort"`
 }
 
 // App is an inspr component that represents an dApp. An App can contain other apps, channels and other components.

--- a/pkg/operator/k8s/deployment.go
+++ b/pkg/operator/k8s/deployment.go
@@ -39,6 +39,10 @@ func WithVolumes(vol ...corev1.Volume) DeploymentOption {
 
 // WithReplicas changes the number of replicas of a deployment
 func WithReplicas(n int) DeploymentOption {
+	if n == 0 {
+		n = 1
+	}
+
 	converted := int32(n)
 	return func(d *appsv1.Deployment) {
 		d.Spec.Replicas = &converted
@@ -77,13 +81,6 @@ func WithAnnotations(labels map[string]string) DeploymentOption {
 			d.Annotations[key] = value
 			d.Spec.Template.Annotations[key] = value
 		}
-	}
-}
-
-// WithRestartPolicy changes the restart policy of the deployment's template
-func WithRestartPolicy(policy corev1.RestartPolicy) DeploymentOption {
-	return func(d *appsv1.Deployment) {
-		d.Spec.Template.Spec.RestartPolicy = policy
 	}
 }
 

--- a/pkg/operator/k8s/deployment_test.go
+++ b/pkg/operator/k8s/deployment_test.go
@@ -430,57 +430,6 @@ func TestWithAnnotations(t *testing.T) {
 	}
 }
 
-func TestWithRestartPolicy(t *testing.T) {
-	type args struct {
-		policy corev1.RestartPolicy
-	}
-	tests := []struct {
-		name string
-		args args
-		want *appsv1.Deployment
-	}{
-		{
-			name: "correct injection",
-			args: args{
-				policy: corev1.RestartPolicyNever,
-			},
-			want: &appsv1.Deployment{
-				Spec: appsv1.DeploymentSpec{
-					Template: corev1.PodTemplateSpec{
-						Spec: corev1.PodSpec{
-							RestartPolicy: corev1.RestartPolicyNever,
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "correct injection",
-			args: args{
-				policy: corev1.RestartPolicyAlways,
-			},
-			want: &appsv1.Deployment{
-				Spec: appsv1.DeploymentSpec{
-					Template: corev1.PodTemplateSpec{
-						Spec: corev1.PodSpec{
-							RestartPolicy: corev1.RestartPolicyAlways,
-						},
-					},
-				},
-			},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			dep := &appsv1.Deployment{}
-			option := WithRestartPolicy(tt.args.policy)
-			option(dep)
-			if !reflect.DeepEqual(dep, tt.want) {
-				t.Errorf("WithVolume() = %v, want %v", dep, tt.want)
-			}
-		})
-	}
-}
 func assertEQ(t *testing.T, f string, got, want interface{}) {
 	t.Helper()
 	if !reflect.DeepEqual(got, want) {


### PR DESCRIPTION
# Description

Kind: Story

Section: Node converter and deployments

Summary:
* I was unable to add a restart policy for the Pods in a deployment. This is because the restartPolicy of a deployment is always "always", and it cannot be configured:
`unexpected inspr error: Deployment.apps" node-a76edf1a-74d6-4b9b-8535-39210257531b "is invalid: spec.template.spec.restartPolicy: Unsupported value:" Never ": supported values:" Always " `
* In case you need to create a pod that doesn't try to restart, we're talking about creating jobs, not deployments. Job creation is a much bigger story that hasn't been discussed yet. Also, to create a job it is necessary to think about how the lbsidecar and sidecar will be notified when the job ends (healthy check). And this is also another story.

So what I did in this story was:

* Deleted option/function of configuring restartPolicy of a deployment
* Deleted the tests of the function that changed the restart policy
* Added support for creating nodes with replicas

## Changelog

* Deleted option/function of configuring restartPolicy of a deployment
* Deleted the tests of the function that changed the restart policy
* Added support for creating nodes with replicas
