### PR TITLE
Bug CORE-547 | Sidecars memory leak and addition of pprof routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 
 # Changelog
 
+### #100 Feat/Fix Pprof/memLeak | adding pprof routes to servers and fixing memory leak
+- fix:
+    - closed the http.Requests and http.Response
+- features:
+    - added the pprof routes in the loadbalancer and services
+
 ### #101 Fix | adds routine for collecting kafka events
 - fix:
     - update kafka go version to 1.7.0

--- a/cmd/authsvc/api/controllers/routes.go
+++ b/cmd/authsvc/api/controllers/routes.go
@@ -11,4 +11,6 @@ func (s *Server) initRoutes() {
 	s.Mux.HandleFunc("/refresh", s.Refresh().Methods(http.MethodGet))
 	s.Mux.HandleFunc("/init", s.HandleInit())
 	s.Mux.HandleFunc("/healthz", rest.Healthz())
+
+	rest.AttachProfiler(s.Mux)
 }

--- a/cmd/authsvc/api/controllers/routes.go
+++ b/cmd/authsvc/api/controllers/routes.go
@@ -12,5 +12,6 @@ func (s *Server) initRoutes() {
 	s.Mux.HandleFunc("/init", s.HandleInit())
 	s.Mux.HandleFunc("/healthz", rest.Healthz())
 
+	// standard paths for /net/http/pprof
 	rest.AttachProfiler(s.Mux)
 }

--- a/cmd/authsvc/api/controllers/routes.go
+++ b/cmd/authsvc/api/controllers/routes.go
@@ -12,6 +12,9 @@ func (s *Server) initRoutes() {
 	s.Mux.HandleFunc("/init", s.HandleInit())
 	s.Mux.HandleFunc("/healthz", rest.Healthz())
 
+<<<<<<< HEAD
 	// standard paths for /net/http/pprof
+=======
+>>>>>>> 0a33d610 (dev(servers): added the route for pprof in all inspr services, still missing for pods/dapps created)
 	rest.AttachProfiler(s.Mux)
 }

--- a/cmd/authsvc/api/controllers/routes.go
+++ b/cmd/authsvc/api/controllers/routes.go
@@ -12,9 +12,6 @@ func (s *Server) initRoutes() {
 	s.Mux.HandleFunc("/init", s.HandleInit())
 	s.Mux.HandleFunc("/healthz", rest.Healthz())
 
-<<<<<<< HEAD
 	// standard paths for /net/http/pprof
-=======
->>>>>>> 0a33d610 (dev(servers): added the route for pprof in all inspr services, still missing for pods/dapps created)
 	rest.AttachProfiler(s.Mux)
 }

--- a/cmd/insprd/operators/nodes/converter.go
+++ b/cmd/insprd/operators/nodes/converter.go
@@ -69,9 +69,6 @@ func (no *NodeOperator) dAppToDeployment(app *meta.App) *kubeDeployment {
 	nodeContainer := createNodeContainer(app, appDeployName)
 	scContainers := no.withAllSidecarsContainers(app, appDeployName)
 
-	temp, _ := strconv.Atoi(os.Getenv("INSPR_LBSIDECAR_PORT"))
-	lbsidecarPort = int32(temp)
-
 	return (*kubeDeployment)(
 		k8s.NewDeployment(
 			appDeployName,

--- a/cmd/insprd/operators/nodes/converter.go
+++ b/cmd/insprd/operators/nodes/converter.go
@@ -69,6 +69,9 @@ func (no *NodeOperator) dAppToDeployment(app *meta.App) *kubeDeployment {
 	nodeContainer := createNodeContainer(app, appDeployName)
 	scContainers := no.withAllSidecarsContainers(app, appDeployName)
 
+	temp, _ := strconv.Atoi(os.Getenv("INSPR_LBSIDECAR_PORT"))
+	lbsidecarPort = int32(temp)
+
 	return (*kubeDeployment)(
 		k8s.NewDeployment(
 			appDeployName,

--- a/cmd/uid_provider/api/controller/routes.go
+++ b/cmd/uid_provider/api/controller/routes.go
@@ -27,4 +27,7 @@ func (s *Server) initRoutes() {
 	s.mux.Handle("/healthz", rest.Healthz())
 
 	s.mux.Handle("/log/level", alevel)
+
+	// standard paths for /net/http/pprof
+	rest.AttachProfiler(s.mux)
 }

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -21,4 +21,3 @@ Summary:
 > Important parts of the code that require special attention
 
 
-"kebab-case-hello-world"

--- a/examples/pingpong_demo/yamls/nodes/ping.app.yaml
+++ b/examples/pingpong_demo/yamls/nodes/ping.app.yaml
@@ -8,7 +8,7 @@ spec:
   logLevel: debug
   node:
     spec:
-      replicas: 3
+      replicas: 1
       image: gcr.io/insprlabs/inspr/example/ping:latest
       environment:
         SUPER_SECRET_0001: "false"

--- a/pkg/api/controllers/routes.go
+++ b/pkg/api/controllers/routes.go
@@ -1,6 +1,8 @@
 package controller
 
 import (
+	"net/http/pprof"
+
 	"inspr.dev/inspr/pkg/rest"
 
 	handler "inspr.dev/inspr/pkg/api/handlers"
@@ -39,4 +41,14 @@ func (s *Server) initRoutes() {
 	s.mux.Handle("/healthz", rest.Healthz())
 
 	s.mux.Handle("/log/level", alevel)
+
+	s.mux.HandleFunc("/debug/pprof/", pprof.Index)
+	s.mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	s.mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	s.mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+
+	s.mux.Handle("/debug/pprof/goroutine", pprof.Handler("goroutine"))
+	s.mux.Handle("/debug/pprof/heap", pprof.Handler("heap"))
+	s.mux.Handle("/debug/pprof/threadcreate", pprof.Handler("threadcreate"))
+	s.mux.Handle("/debug/pprof/block", pprof.Handler("block"))
 }

--- a/pkg/api/controllers/routes.go
+++ b/pkg/api/controllers/routes.go
@@ -1,8 +1,6 @@
 package controller
 
 import (
-	"net/http/pprof"
-
 	"inspr.dev/inspr/pkg/rest"
 
 	handler "inspr.dev/inspr/pkg/api/handlers"
@@ -42,13 +40,6 @@ func (s *Server) initRoutes() {
 
 	s.mux.Handle("/log/level", alevel)
 
-	s.mux.HandleFunc("/debug/pprof/", pprof.Index)
-	s.mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
-	s.mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
-	s.mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
-
-	s.mux.Handle("/debug/pprof/goroutine", pprof.Handler("goroutine"))
-	s.mux.Handle("/debug/pprof/heap", pprof.Handler("heap"))
-	s.mux.Handle("/debug/pprof/threadcreate", pprof.Handler("threadcreate"))
-	s.mux.Handle("/debug/pprof/block", pprof.Handler("block"))
+	// standard paths for /net/http/pprof
+	rest.AttachProfiler(s.mux)
 }

--- a/pkg/rest/request/request.go
+++ b/pkg/rest/request/request.go
@@ -37,7 +37,6 @@ func (c Client) Send(ctx context.Context, route, method string, body, responsePt
 		c.routeToURL(route),
 		bytes.NewBuffer(buf),
 	)
-
 	if err != nil {
 		return ierrors.
 			NewError().
@@ -46,6 +45,7 @@ func (c Client) Send(ctx context.Context, route, method string, body, responsePt
 			InnerError(err).
 			Build()
 	}
+	defer req.Body.Close()
 
 	for key, values := range c.headers {
 		req.Header[key] = values
@@ -73,6 +73,7 @@ func (c Client) Send(ctx context.Context, route, method string, body, responsePt
 			Message(err.Error()).
 			Build()
 	}
+	defer resp.Body.Close()
 
 	err = c.handleResponseErr(resp)
 	if err != nil {

--- a/pkg/rest/utils.go
+++ b/pkg/rest/utils.go
@@ -10,8 +10,11 @@ import (
 	"inspr.dev/inspr/pkg/ierrors"
 )
 
+<<<<<<< HEAD
 // AttachProfiler is responsible for adding the pprof routes to the server mux
 // passed as a parameter
+=======
+>>>>>>> 0a33d610 (dev(servers): added the route for pprof in all inspr services, still missing for pods/dapps created)
 func AttachProfiler(m *http.ServeMux) {
 	m.HandleFunc("/debug/pprof/", pprof.Index)
 	m.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)

--- a/pkg/rest/utils.go
+++ b/pkg/rest/utils.go
@@ -10,11 +10,8 @@ import (
 	"inspr.dev/inspr/pkg/ierrors"
 )
 
-<<<<<<< HEAD
 // AttachProfiler is responsible for adding the pprof routes to the server mux
 // passed as a parameter
-=======
->>>>>>> 0a33d610 (dev(servers): added the route for pprof in all inspr services, still missing for pods/dapps created)
 func AttachProfiler(m *http.ServeMux) {
 	m.HandleFunc("/debug/pprof/", pprof.Index)
 	m.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)

--- a/pkg/rest/utils.go
+++ b/pkg/rest/utils.go
@@ -10,6 +10,8 @@ import (
 	"inspr.dev/inspr/pkg/ierrors"
 )
 
+// AttachProfiler is responsible for adding the pprof routes to the server mux
+// passed as a parameter
 func AttachProfiler(m *http.ServeMux) {
 	m.HandleFunc("/debug/pprof/", pprof.Index)
 	m.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)

--- a/pkg/rest/utils.go
+++ b/pkg/rest/utils.go
@@ -5,9 +5,23 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/http/pprof"
 
 	"inspr.dev/inspr/pkg/ierrors"
 )
+
+func AttachProfiler(m *http.ServeMux) {
+	m.HandleFunc("/debug/pprof/", pprof.Index)
+	m.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+	m.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	m.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+
+	// Manually add support for paths linked to by index page at /debug/pprof/
+	m.Handle("/debug/pprof/goroutine", pprof.Handler("goroutine"))
+	m.Handle("/debug/pprof/heap", pprof.Handler("heap"))
+	m.Handle("/debug/pprof/threadcreate", pprof.Handler("threadcreate"))
+	m.Handle("/debug/pprof/block", pprof.Handler("block"))
+}
 
 // RecoverFromPanic will handle panic
 func RecoverFromPanic(w http.ResponseWriter) {

--- a/pkg/sidecars/lbsidecar/handlers.go
+++ b/pkg/sidecars/lbsidecar/handlers.go
@@ -81,6 +81,7 @@ func (s *Server) writeMessageHandler() rest.Handler {
 			rest.ERROR(w, err)
 			return
 		}
+		defer resp.Body.Close()
 
 		rest.JSON(w, resp.StatusCode, resp.Body)
 	}
@@ -137,6 +138,7 @@ func (s *Server) readMessageHandler() rest.Handler {
 			rest.ERROR(w, err)
 			return
 		}
+		defer resp.Body.Close()
 
 		rest.JSON(w, resp.StatusCode, resp.Body)
 	}
@@ -148,6 +150,7 @@ func sendRequest(addr string, body []byte) (*http.Response, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer req.Body.Close()
 
 	resp, err := client.Do(req)
 	if err != nil {

--- a/pkg/sidecars/lbsidecar/server.go
+++ b/pkg/sidecars/lbsidecar/server.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"go.uber.org/zap"
+	"inspr.dev/inspr/pkg/rest"
 )
 
 // Server is a struct that contains the variables necessary
@@ -41,8 +42,11 @@ func (s *Server) Run(ctx context.Context) error {
 	errCh := make(chan error)
 
 	mux := http.NewServeMux()
+
+	rest.AttachProfiler(mux)
 	mux.Handle("/log/level", alevel)
 	mux.Handle("/", s.writeMessageHandler().Post().JSON())
+
 	writeServer := &http.Server{
 		Handler: mux,
 		Addr:    s.writeAddr,

--- a/pkg/sidecars/server/handlers.go
+++ b/pkg/sidecars/server/handlers.go
@@ -124,6 +124,7 @@ func (s *Server) writeWithRetry(ctx context.Context, channel string, data []byte
 		if err == nil && status == http.StatusOK {
 			return
 		}
+		defer resp.Body.Close()
 		err = rest.UnmarshalERROR(resp.Body)
 	}
 

--- a/pkg/sidecars/server/server.go
+++ b/pkg/sidecars/server/server.go
@@ -10,6 +10,7 @@ import (
 	"go.uber.org/zap"
 	"inspr.dev/inspr/cmd/insprd/memory/brokers"
 	"inspr.dev/inspr/pkg/logs"
+	"inspr.dev/inspr/pkg/rest"
 	"inspr.dev/inspr/pkg/sidecars/models"
 )
 
@@ -67,12 +68,16 @@ func Init(r models.Reader, w models.Writer, broker string) *Server {
 // Run starts the server on the port given in addr
 func (s *Server) Run(ctx context.Context) error {
 	mux := http.NewServeMux()
+
+	rest.AttachProfiler(mux)
 	mux.Handle("/log/level", alevel)
 	mux.Handle("/", s.writeMessageHandler().Post().JSON())
+
 	server := &http.Server{
 		Handler: mux,
 		Addr:    s.inAddr,
 	}
+
 	errCh := make(chan error)
 	// create read message routine and captures its error
 	go func() { errCh <- s.readMessageRoutine(ctx) }()


### PR DESCRIPTION
# Description

Kind: feature
<!-- Specify the kind of the pull request, as in if it's a Bug fix, a Feature, a Story, a Tech Pendency, etc.
-->

Section: servers for all services and possibly dapss
<!-- Section can be the specific folder or file refered by the pull request, like "pkg/ierrors", or a most wide section that comprehends multiple folders and files, like "Sidecar".
-->

Summary: The main idea is to create a route that allows us to use the golang tool called `pprof` which generates a graphs about many differente subjects, such as, goroutines, heap, cpu etc.
<!-- A quick description of what was changed, fixed or implemented (e.g. "Configured all Insprd routes to validate authentication")
-->

## Changelog

> List the main points of change
- created the AttachProfiler func in the rest package, responsible for adding the routes of pprof to any `http.ServeMux`.
- Added the func call in the server of each service of Inpsr: `insprd`, `uidp`, `auth-svc`.
- Added the pprof routes on the load balancer
- **Fixed** the memory leak, http.Request and http.Response were not being closed
