### PR TITLE
fix(cli/init) Bug: Cli initialization not adding "http://" to ip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 
 # Changelog
 
+### #112 Bug CORE-569 | Cli initialization not adding "http://" to ip
+- fix:
+	- added http:// on the `serverip` on the `insprctl init` command
+---
+
 ### #110 Story CORE-246 | Develop a client (for sidecar communication) with Python
 - features:
     - Created the newClient, writeMessage, handleChannel and run functions for the lb sidecar client for python

--- a/cmd/insprctl/cli/init.go
+++ b/cmd/insprctl/cli/init.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"gopkg.in/yaml.v2"
 	"inspr.dev/inspr/pkg/cmd"
@@ -37,6 +38,9 @@ var initCommand = cmd.NewCmd("init").
 		config := insprConfiguration{}
 		fmt.Print("enter insprd IP or URL (localhost:8080):")
 		fmt.Scanln(&config.ServerIP)
+		if !strings.HasPrefix(config.ServerIP, "http") {
+			config.ServerIP = fmt.Sprintf("http://%s", config.ServerIP)
+		}
 		if config.ServerIP == "" {
 			config.ServerIP = "http://localhost:8080"
 		}


### PR DESCRIPTION
# Description

Kind: Bug

Section: Cli init

Summary: Added http prefix if the serverip sent didn't already have it

## Changelog

- fix:
	- added http:// on the `serverip` on the `insprctl init` command