### PR TITLE
Bug CORE-578 | Deploying Types without schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### #136 Bug CORE-578 | Deploying Types without schemas
+- fix:
+    - implemented type scheme validation according to avro and Json rules 
+---
+
 ### #133 Feature Grafana dashboards | Automatically create becnhmark dashboard on grafana deploy
 - feature:
   - Added support for custom dashboards in grafana values

--- a/cmd/insprctl/cli/apply_type.go
+++ b/cmd/insprctl/cli/apply_type.go
@@ -2,6 +2,8 @@ package cli
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
@@ -39,7 +41,11 @@ func NewApplyType() RunMethod {
 			if err != nil {
 				return err
 			}
+		} else if !IsJSON(insprType.Schema) {
+			return ierrors.New("invalid type schema")
 		}
+
+		fmt.Println(insprType.Schema)
 
 		flagDryRun := cmd.InsprOptions.DryRun
 		flagIsUpdate := cmd.InsprOptions.Update
@@ -93,4 +99,9 @@ func injectedSchema(path string) (string, error) {
 	schema := string(file)
 
 	return schema, nil
+}
+
+func IsJSON(str string) bool {
+	var js json.RawMessage
+	return json.Unmarshal([]byte(str), &js) == nil
 }

--- a/cmd/insprctl/cli/apply_type.go
+++ b/cmd/insprctl/cli/apply_type.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
@@ -44,8 +43,6 @@ func NewApplyType() RunMethod {
 		} else if !IsJSON(insprType.Schema) {
 			return ierrors.New("invalid type schema")
 		}
-
-		fmt.Println(insprType.Schema)
 
 		flagDryRun := cmd.InsprOptions.DryRun
 		flagIsUpdate := cmd.InsprOptions.Update

--- a/cmd/insprctl/cli/apply_type_test.go
+++ b/cmd/insprctl/cli/apply_type_test.go
@@ -23,8 +23,20 @@ func createSchema() string {
 
 func TestNewApplyType(t *testing.T) {
 	prepareToken(t)
-	chanTypeWithoutNameBytes, _ := yaml.Marshal(meta.Type{})
-	chanTypeDefaultBytes, _ := yaml.Marshal(meta.Type{Meta: meta.Metadata{Name: "mock"}})
+	typeWithoutNameBytes, _ := yaml.Marshal(meta.Type{
+		Schema: "{\"type\":\"string\"}",
+	})
+	typeWithoutSchema, _ := yaml.Marshal(meta.Type{
+		Meta: meta.Metadata{
+			Name: "mock",
+		},
+	})
+	typeDefaultBytes, _ := yaml.Marshal(meta.Type{
+		Meta: meta.Metadata{
+			Name: "mock",
+		},
+		Schema: "{\"type\":\"string\"}",
+	})
 	type args struct {
 		b []byte
 	}
@@ -36,21 +48,28 @@ func TestNewApplyType(t *testing.T) {
 		{
 			name: "default_test",
 			args: args{
-				b: chanTypeDefaultBytes,
+				b: typeDefaultBytes,
 			},
 			want: nil,
 		},
 		{
 			name: "type_without_name",
 			args: args{
-				b: chanTypeWithoutNameBytes,
+				b: typeWithoutNameBytes,
 			},
 			want: ierrors.New("type without name"),
 		},
 		{
+			name: "invalid scheme type",
+			args: args{
+				b: typeWithoutSchema,
+			},
+			want: ierrors.New("invalid type schema"),
+		},
+		{
 			name: "error_testing",
 			args: args{
-				b: chanTypeDefaultBytes,
+				b: typeDefaultBytes,
 			},
 			want: errors.New("new error"),
 		},

--- a/cmd/insprd/memory/tree/types.go
+++ b/cmd/insprd/memory/tree/types.go
@@ -1,6 +1,7 @@
 package tree
 
 import (
+	"github.com/linkedin/goavro"
 	"go.uber.org/zap"
 	"inspr.dev/inspr/pkg/ierrors"
 	"inspr.dev/inspr/pkg/meta"
@@ -38,6 +39,12 @@ func (tmm *TypeMemoryManager) Create(scope string, insprType *meta.Type) error {
 	err := utils.StructureNameIsValid(insprType.Meta.Name)
 	if err != nil {
 		l.Error("invalid Type name")
+		return err
+	}
+
+	err = validAvroSchema(insprType.Schema)
+	if err != nil {
+		l.Error("invalid Type schema")
 		return err
 	}
 
@@ -220,4 +227,12 @@ func (trg *TypePermTreeGetter) Get(scope, name string) (*meta.Type, error) {
 	l.Info("unable to get Type in given scope (root-tree)")
 
 	return nil, ierrors.New("Type not found for given query on root").NotFound()
+}
+
+func validAvroSchema(schema string) error {
+	_, err := goavro.NewCodec(schema)
+	if err != nil {
+		return ierrors.Wrap(err, "invalid avro schema")
+	}
+	return nil
 }

--- a/cmd/insprd/memory/tree/types_test.go
+++ b/cmd/insprd/memory/tree/types_test.go
@@ -164,6 +164,30 @@ func TestTypeMemoryManager_Create(t *testing.T) {
 		want    *meta.Type
 	}{
 		{
+			name: "Trying to create a new Type with invalid schema",
+			fields: fields{
+				root:   getMockTypes(),
+				appErr: nil,
+				mockA:  true,
+				mockC:  true,
+				mockCT: false,
+			},
+			args: args{
+				ct: &meta.Type{
+					Meta: meta.Metadata{
+						Name:        "ct7",
+						Reference:   "ct1",
+						Annotations: map[string]string{},
+						Parent:      "",
+						UUID:        "",
+					},
+					Schema: "",
+				},
+				context: "",
+			},
+			wantErr: true,
+		},
+		{
 			name: "Creating a new Type on a valid app",
 			fields: fields{
 				root:   getMockTypes(),
@@ -181,7 +205,7 @@ func TestTypeMemoryManager_Create(t *testing.T) {
 						Parent:      "",
 						UUID:        "",
 					},
-					Schema: "",
+					Schema: "{\"type\":\"string\"}",
 				},
 				context: "",
 			},
@@ -194,7 +218,7 @@ func TestTypeMemoryManager_Create(t *testing.T) {
 					Parent:      "",
 					UUID:        "",
 				},
-				Schema: "",
+				Schema: "{\"type\":\"string\"}",
 			},
 		},
 		{
@@ -215,7 +239,7 @@ func TestTypeMemoryManager_Create(t *testing.T) {
 						Parent:      "",
 						UUID:        "",
 					},
-					Schema: "",
+					Schema: "{\"type\":\"string\"}",
 				},
 				context: "",
 			},
@@ -249,7 +273,7 @@ func TestTypeMemoryManager_Create(t *testing.T) {
 						Parent:      "",
 						UUID:        "",
 					},
-					Schema: "",
+					Schema: "{\"type\":\"string\"}",
 				},
 				context: "invalid.context",
 			},
@@ -274,7 +298,7 @@ func TestTypeMemoryManager_Create(t *testing.T) {
 						Parent:      "",
 						UUID:        "",
 					},
-					Schema: "",
+					Schema: "{\"type\":\"string\"}",
 				},
 				context: "",
 			},


### PR DESCRIPTION
# Description

Kind: Fix

Section: Memory, CLI

Summary: Fixed wrongful application of types without valid schema

## Changelog

- fix:
    - implemented type scheme validation according to avro and Json rules 



