### PR TITLE
Story CORE-579 | [BETA] Change lb-sidecars channel resolution to account for the '/channel' that will now be required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+### #137 Story CORE-579 | Change lb-sidecars channel resolution to account for the '/channel' that will now be required
+- feature:
+  - server now watching just for the "/channel" prefix
+  - added "/channel" prefix when handling a channel
+  - added "/channel" prefix when writing a message
+- fix:
+  - fix python import module bug
+  - update/fix lb sidecar tests due to the change above
+  - update some logs in lb sidecar
+---
+
 ### #133 Feature Grafana dashboards | Automatically create becnhmark dashboard on grafana deploy
 - feature:
   - Added support for custom dashboards in grafana values

--- a/clients/python/inspr/__init__.py
+++ b/clients/python/inspr/__init__.py
@@ -1,4 +1,4 @@
 from .client import *
 from .rest import *
 from .models import *
-from .controller.controller_client import *
+from .controller.controller_client import ControllerClient

--- a/clients/python/inspr/client.py
+++ b/clients/python/inspr/client.py
@@ -20,7 +20,7 @@ class Client:
             "data": msg
         }
         try:
-            send_post_request(self.write_address + "/" + channel, msg_body)
+            send_post_request(self.write_address + "/channel/" + channel, msg_body)
         except Exception as e:
             print(f"Error while trying to write message: {e}")
             raise Exception("failed to deliver message: channel: {}".format(channel))
@@ -37,7 +37,7 @@ class Client:
 
                 return '', HTTPStatus.OK
 
-            self.app.add_url_rule("/" + channel, endpoint = channel, view_func = route_func, methods=["POST"])
+            self.app.add_url_rule("/channel/" + channel, endpoint = channel, view_func = route_func, methods=["POST"])
             return handle_func
         return wrapper
 

--- a/clients/python/setup.py
+++ b/clients/python/setup.py
@@ -5,14 +5,15 @@ with open("README.md", "r") as fh:
 
 setup(
     name="inspr",
-    version="0.0.2",
+    version="0.0.11",
     author="Inspr LLC",
     description="This module define APIs to interact with the Inspr environment",
     long_description=long_description,      # Long description read from the the readme file
     long_description_content_type="text/markdown",
-    python_requires='>=3.6',
+    python_requires='>=3.8',
     packages=[
         "inspr",
+        "inspr.controller"
     ],
     requires=[
         "requests",

--- a/examples/python/pingpong/Makefile
+++ b/examples/python/pingpong/Makefile
@@ -1,6 +1,6 @@
 build:
-	docker build -t gcr.io/insprlabs/inspr/example/python/ping:latest -f ping/ping.Dockerfile .
+	docker build --no-cache -t gcr.io/insprlabs/inspr/example/python/ping:latest -f ping/ping.Dockerfile .
 	docker push gcr.io/insprlabs/inspr/example/python/ping:latest
 
-	docker build -t gcr.io/insprlabs/inspr/example/python/pong:latest -f pong/pong.Dockerfile .
+	docker build --no-cache -t gcr.io/insprlabs/inspr/example/python/pong:latest -f pong/pong.Dockerfile .
 	docker push gcr.io/insprlabs/inspr/example/python/pong:latest

--- a/examples/python/pingpong/deployAll.sh
+++ b/examples/python/pingpong/deployAll.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+insprctl brokers kafka yamls/kafkaConfig.yaml
+sleep 2
+
+insprctl apply -k yamls/ctypes
+sleep 2
+
+insprctl apply -k yamls/channels
+sleep 2
+
+insprctl apply -f yamls/table.yaml
+sleep 2
+
+insprctl apply -k yamls/nodes
+sleep 2

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -61,7 +61,7 @@ func (c *Client) WriteMessage(ctx context.Context, channel string, msg interface
 	l.Debug("sending message to load balancer")
 	err := c.client.Send(
 		ctx,
-		"/"+channel,
+		"/channel/"+channel,
 		http.MethodPost,
 		data,
 		&resp)
@@ -75,7 +75,7 @@ func (c *Client) WriteMessage(ctx context.Context, channel string, msg interface
 
 // HandleChannel handles messages received in a given channel.
 func (c *Client) HandleChannel(channel string, handler func(ctx context.Context, body io.Reader) error) {
-	c.mux.HandleFunc("/"+channel, func(w http.ResponseWriter, r *http.Request) {
+	c.mux.HandleFunc("/channel/"+channel, func(w http.ResponseWriter, r *http.Request) {
 		l := logger.With(zap.String("operation", "write"), zap.String("channel", channel))
 		// user defined handler. Returns error if the user wants to return it
 		l.Info("received read message request")

--- a/pkg/client/client_test.go
+++ b/pkg/client/client_test.go
@@ -171,7 +171,7 @@ func TestClient_WriteMessage(t *testing.T) {
 			if tt.cancelContext {
 				handler = mockHandlerFuncTimeout()
 			} else {
-				handler = mockHandlerFunc("/chan1", tt.args)
+				handler = mockHandlerFunc("/channel/chan1", tt.args)
 			}
 
 			s := httptest.NewServer(http.HandlerFunc(handler))
@@ -282,7 +282,7 @@ func TestClient_HandleChannel(t *testing.T) {
 			}{}
 			err := client.Send(
 				context.Background(),
-				tt.args.channel,
+				"/channel/"+tt.args.channel,
 				http.MethodPost,
 				struct{ Message interface{} }{tt.message},
 				&response)
@@ -353,7 +353,7 @@ func TestClient_Run(t *testing.T) {
 				errch <- client.Run(ctx)
 			}()
 
-			c := request.NewJSONClient("http://localhost:3304")
+			c := request.NewJSONClient("http://localhost:3304/channel")
 			var response struct {
 				Status string `json:"status"`
 			}

--- a/pkg/rest/request/request.go
+++ b/pkg/rest/request/request.go
@@ -55,7 +55,7 @@ func (c Client) Send(ctx context.Context, route, method string, body, responsePt
 		bytes.NewBuffer(buf),
 	)
 
-	logger.Info("Sending request to:" + c.routeToURL(route))
+	logger.Debug("Sending request to:" + c.routeToURL(route))
 
 	if err != nil {
 		return ierrors.Wrap(err, "error creating request")

--- a/pkg/rest/request/request.go
+++ b/pkg/rest/request/request.go
@@ -7,9 +7,18 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"os"
 
+	"go.uber.org/zap"
 	"inspr.dev/inspr/pkg/ierrors"
+	"inspr.dev/inspr/pkg/logs"
 )
+
+var logger *zap.Logger
+
+func init() {
+	logger, _ = logs.Logger(zap.Fields(zap.String("section", "sidecar-client"), zap.String("dapp-name", os.Getenv("INSPR_APP_ID"))))
+}
 
 const (
 	// DefaultHost is the the standard hostname, it is used in requests made by
@@ -45,6 +54,8 @@ func (c Client) Send(ctx context.Context, route, method string, body, responsePt
 		c.routeToURL(route),
 		bytes.NewBuffer(buf),
 	)
+
+	logger.Info("Sending request to:" + c.routeToURL(route))
 
 	if err != nil {
 		return ierrors.Wrap(err, "error creating request")

--- a/pkg/sidecars/lbsidecar/handlers.go
+++ b/pkg/sidecars/lbsidecar/handlers.go
@@ -30,9 +30,10 @@ func init() {
 func (s *Server) writeMessageHandler() rest.Handler {
 	return func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
-		logger.Info("handling message write")
 
-		channel := strings.TrimPrefix(r.URL.Path, "/")
+		channel := strings.TrimPrefix(r.URL.Path, "/channel/")
+		logger.Info("handling message write on " + channel)
+
 		if !environment.OutputChannelList().Contains(channel) {
 			logger.Error(fmt.Sprintf("channel %s not found in output channel list", channel))
 
@@ -56,7 +57,7 @@ func (s *Server) writeMessageHandler() rest.Handler {
 		sidecarAddress := environment.GetBrokerSpecificSidecarAddr(channelBroker)
 		sidecarWritePort := environment.GetBrokerWritePort(channelBroker)
 
-		reqAddress := fmt.Sprintf("%s:%s/%s", sidecarAddress, sidecarWritePort, channel)
+		reqAddress := fmt.Sprintf("%s:%s/channel/%s", sidecarAddress, sidecarWritePort, channel)
 
 		logger.Debug("encoding message to Avro schema")
 
@@ -96,9 +97,9 @@ func (s *Server) writeMessageHandler() rest.Handler {
 func (s *Server) readMessageHandler() rest.Handler {
 	return func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
-		logger.Info("handling message read")
 
-		channel := strings.TrimPrefix(r.URL.Path, "/")
+		channel := strings.TrimPrefix(r.URL.Path, "/channel/")
+		logger.Info("handling message read on " + channel)
 
 		if !environment.InputChannelList().Contains(channel) {
 			logger.Error("channel " + channel + " not found in input channel list")
@@ -135,7 +136,7 @@ func (s *Server) readMessageHandler() rest.Handler {
 		logger.Info("sending message to node through: ",
 			zap.String("channel", channel), zap.String("node port", clientReadPort))
 
-		reqAddress := fmt.Sprintf("http://localhost:%v/%v", clientReadPort, channel)
+		reqAddress := fmt.Sprintf("http://localhost:%v/channel/%v", clientReadPort, channel)
 
 		resp, err := sendRequest(reqAddress, decodedMsg)
 		if err != nil {

--- a/pkg/sidecars/lbsidecar/handlers_test.go
+++ b/pkg/sidecars/lbsidecar/handlers_test.go
@@ -25,7 +25,7 @@ func createMockedServer(port, ch string, msg interface{}) *httptest.Server {
 
 	ts := httptest.NewUnstartedServer(http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
-			channel := strings.TrimPrefix(r.URL.Path, "/")
+			channel := strings.TrimPrefix(r.URL.Path, "/channel/")
 
 			var receivedData models.BrokerMessage
 			json.NewDecoder(r.Body).Decode(&receivedData)
@@ -117,7 +117,7 @@ func TestServer_writeMessageHandler(t *testing.T) {
 
 			buf, _ := json.Marshal(tt.msg)
 			reqInfo, _ := http.NewRequest(http.MethodPost,
-				wServer.URL+"/"+tt.channel,
+				wServer.URL+"/channel/"+tt.channel,
 				bytes.NewBuffer(buf))
 
 			resp, err := req.Do(reqInfo)
@@ -216,7 +216,7 @@ func TestServer_readMessageHandler(t *testing.T) {
 				return
 			}
 			reqInfo, _ := http.NewRequest(http.MethodPost,
-				rServer.URL+"/"+tt.channel,
+				rServer.URL+"/channel/"+tt.channel,
 				bytes.NewBuffer(buf))
 
 			resp, err := req.Do(reqInfo)

--- a/pkg/sidecars/lbsidecar/server.go
+++ b/pkg/sidecars/lbsidecar/server.go
@@ -145,7 +145,7 @@ func (s *Server) Run(ctx context.Context) error {
 		Addr:    "0.0.0.0:16000",
 	}
 	go func() {
-		logger.Info("admin server listening at localhos:16000")
+		logger.Info("admin server listening at localhost:16000")
 		if err := adminServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			errCh <- err
 			logger.Error("an error occurred in LB Sidecar write server",
@@ -155,7 +155,7 @@ func (s *Server) Run(ctx context.Context) error {
 
 	mux := http.NewServeMux()
 
-	mux.Handle("/", s.writeMessageHandler().Post().JSON())
+	mux.Handle("/channel/", s.writeMessageHandler().Post().JSON())
 
 	writeServer := &http.Server{
 		Handler: mux,

--- a/pkg/sidecars/lbsidecar/server.go
+++ b/pkg/sidecars/lbsidecar/server.go
@@ -153,12 +153,12 @@ func (s *Server) Run(ctx context.Context) error {
 		}
 	}()
 
-	mux := http.NewServeMux()
+	muxWriter := http.NewServeMux()
 
-	mux.Handle("/channel/", s.writeMessageHandler().Post().JSON())
+	muxWriter.Handle("/channel/", s.writeMessageHandler().Post().JSON())
 
 	writeServer := &http.Server{
-		Handler: mux,
+		Handler: muxWriter,
 		Addr:    s.writeAddr,
 	}
 	go func() {
@@ -169,8 +169,12 @@ func (s *Server) Run(ctx context.Context) error {
 		}
 	}()
 
+	muxReader := http.NewServeMux()
+
+	muxReader.Handle("/channel/", s.readMessageHandler().Post().JSON())
+
 	readServer := &http.Server{
-		Handler: s.readMessageHandler().Post().JSON(),
+		Handler: muxReader,
 		Addr:    s.readAddr,
 	}
 	go func() {

--- a/pkg/sidecars/server/handlers.go
+++ b/pkg/sidecars/server/handlers.go
@@ -22,9 +22,8 @@ func (s *Server) writeMessageHandler() rest.Handler {
 	return func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
 
-		logger.Info("handling message write")
-
-		channel := strings.TrimPrefix(r.URL.Path, "/")
+		channel := strings.TrimPrefix(r.URL.Path, "/channel/")
+		logger.Info("handling message write on " + channel)
 
 		body, err := ioutil.ReadAll(r.Body)
 		if err != nil {
@@ -137,7 +136,7 @@ func (s *Server) writeWithRetry(
 ) (status int, err error) {
 	var resp *http.Response
 	for i := 0; i <= maxBrokerRetries; i++ {
-		writeAddr := fmt.Sprintf("%s/%s", s.outAddr, channel)
+		writeAddr := fmt.Sprintf("%s/channel/%s", s.outAddr, channel)
 		logger.Debug("writing with retry",
 			zap.Any("addr", writeAddr),
 			zap.Any("write conter", i))

--- a/pkg/sidecars/server/handlers_test.go
+++ b/pkg/sidecars/server/handlers_test.go
@@ -143,7 +143,7 @@ func TestServer_writeMessageHandler(t *testing.T) {
 			client := &http.Client{}
 
 			resp, err := client.Post(
-				fmt.Sprintf("%s/%s", server.URL, tt.channel),
+				fmt.Sprintf("%s/channel/%s", server.URL, tt.channel),
 				"application/octet-stream",
 				bytes.NewBuffer(tt.message),
 			)

--- a/pkg/sidecars/server/server.go
+++ b/pkg/sidecars/server/server.go
@@ -137,7 +137,7 @@ func (s *Server) Run(ctx context.Context) error {
 		Addr:    "0.0.0.0:16001",
 	}
 	go func() {
-		logger.Info("admin server listening at localhos:16001")
+		logger.Info("admin server listening at localhost:16001")
 		if err := adminServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			errCh <- err
 			logger.Error("an error occurred in LB Sidecar write server",


### PR DESCRIPTION
# Description

Kind: Feature

Section: Server, client and handlers of lbsidecar

Summary: Added "/channel" to the routes of the read/write. No functionality is changed.

## Changelog

* Server now watching just for the "/channel" prefix
* Added "/channel" prefix when handling a channel
* Added "/channel" prefix when writing a message
* Update/Fix some tests
* Update some logs
