### PR TITLE
Story CORE-588 | [BETA] Configure routes reading on LB-sidecar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+### #139 Story CORE-588 | [BETA] Configure routes reading on LB-sidecar
+- feature:
+  - added route receive handler to the lbsidecar handler
+  - lbsidecar read server now listens for the "/route" path
+  - added tests for the route receive handler
+--- 
+
 ### #137 Story CORE-579 | Change lb-sidecars channel resolution to account for the '/channel' that will now be required
 - feature:
   - server now watching just for the "/channel" prefix

--- a/pkg/sidecars/lbsidecar/handlers.go
+++ b/pkg/sidecars/lbsidecar/handlers.go
@@ -195,7 +195,8 @@ func (s *Server) routeReceiveHandler() rest.Handler {
 		defer resp.Body.Close()
 
 		// Return the response
-		rest.JSON(w, resp.StatusCode, resp.Body)
+		w.WriteHeader(resp.StatusCode)
+		io.Copy(w, resp.Body)
 	}
 }
 

--- a/pkg/sidecars/lbsidecar/handlers_test.go
+++ b/pkg/sidecars/lbsidecar/handlers_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
@@ -44,6 +45,40 @@ func createMockedServer(port, ch string, msg interface{}) *httptest.Server {
 	ts.Listener = l
 
 	return ts
+}
+
+func createRouteMockedServer(port string, expectedMsg interface{}) *httptest.Server {
+	listener, err := net.Listen("tcp", "localhost:"+port)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	mockServer := httptest.NewUnstartedServer(http.HandlerFunc(
+		func(w http.ResponseWriter, r *http.Request) {
+
+			var receivedData string
+			body, err := ioutil.ReadAll(r.Body)
+			if err != nil {
+				rest.ERROR(w, fmt.Errorf("error while reading msg body"))
+				return
+			}
+
+			fmt.Printf("receivedData = %v\n", string(body))
+
+			if expectedMsg != receivedData {
+				rest.ERROR(w, fmt.Errorf("invalid message"))
+				return
+			}
+
+			rest.JSON(w, http.StatusOK, nil)
+		}),
+	)
+
+	mockServer.Listener.Close()
+	mockServer.Listener = listener
+
+	return mockServer
+
 }
 
 func TestServer_writeMessageHandler(t *testing.T) {
@@ -234,6 +269,64 @@ func TestServer_readMessageHandler(t *testing.T) {
 				t.Errorf("Received status %v, wanted %v", resp.StatusCode, http.StatusOK)
 				return
 			}
+		})
+	}
+}
+
+func TestServer_routeReceiveHandler(t *testing.T) {
+
+	createMockEnvVars()
+	defer deleteMockEnvVars()
+
+	rServer := httptest.NewServer(Init().routeReceiveHandler())
+	req := http.Client{}
+
+	tests := []struct {
+		name          string
+		msg           models.BrokerMessage
+		endpoint      string
+		port          string
+		setClientPort bool
+		wantErr       bool
+		want          rest.Handler
+	}{
+		{
+			name: "Valid route request",
+			msg: models.BrokerMessage{
+				Data: "Hello World!",
+			},
+			endpoint:      "hello",
+			port:          "1171",
+			setClientPort: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			if tt.setClientPort {
+				os.Setenv("INSPR_SCCLIENT_READ_PORT", "1171")
+				defer os.Unsetenv("INSPR_SCCLIENT_READ_PORT")
+			}
+
+			var testServer *httptest.Server
+			if tt.port != "" {
+				testServer = createRouteMockedServer(tt.port, tt.msg.Data.(string))
+				testServer.Start()
+				defer testServer.Close()
+			}
+
+			reqInfo, _ := http.NewRequest(http.MethodPost, rServer.URL+"/route/"+tt.endpoint, bytes.NewBuffer([]byte("Hello World")))
+
+			resp, err := req.Do(reqInfo)
+			if err != nil {
+				t.Errorf("Error while doing the request: %v", err)
+				return
+			}
+
+			fmt.Println(resp)
+
+			t.FailNow()
+
 		})
 	}
 }

--- a/pkg/sidecars/lbsidecar/handlers_test.go
+++ b/pkg/sidecars/lbsidecar/handlers_test.go
@@ -296,6 +296,12 @@ func TestServer_routeReceiveHandler(t *testing.T) {
 			port:          "1171",
 			setClientPort: true,
 		},
+		{
+			name:     "Invalid - port not set",
+			msg:      "Hello World!",
+			endpoint: "hello",
+			wantErr:  true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/sidecars/lbsidecar/server.go
+++ b/pkg/sidecars/lbsidecar/server.go
@@ -172,6 +172,7 @@ func (s *Server) Run(ctx context.Context) error {
 	muxReader := http.NewServeMux()
 
 	muxReader.Handle("/channel/", s.readMessageHandler().Post().JSON())
+	muxReader.Handle("/route/", s.routeReceiveHandler().Post().JSON())
 
 	readServer := &http.Server{
 		Handler: muxReader,


### PR DESCRIPTION
# Description

Kind: Feature

Section: lbsidecar handlers

Summary: Added the route receive handler to the lbsidecar read server

## Changelog
* Added route receive handler to the lbsidecar handler
* lbsidecar read server now listens for the "/route" path
* Added tests for the route receive handler


