### PR TITLE
Story CORE-591 | Implement benchmarking dapp out of Inspr Stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+### #147 Story CORE-591 | Implement benchmarking dapp out of Inspr Stack
+- features:
+  - implemented k8s job for creating "kafka-test" topic on kafka
+  - implemented k8s job for deleting "kafka-test" topic on kafka
+  - implemented k8s deployment for app that sends messages non stop on "kafka-test" topic
+  - implemented k8s deployment for app that reads messages non stop from "kafka-test" topic
+  - created Makefile and dockerfiles to compile images 
+---
+
 ### #144 Story CORE-599 | [BETA] Route-Demo readme
 - doc:
   - described route demo example and how to deploy it

--- a/examples/kafka_standalone/Makefile
+++ b/examples/kafka_standalone/Makefile
@@ -1,0 +1,5 @@
+build:
+	docker build -t gcr.io/insprlabs/inspr/example/kafkasa/create:latest -f topic/create/create.Dockerfile ../..
+	docker push gcr.io/insprlabs/inspr/example/kafkasa/create:latest
+	docker build -t gcr.io/insprlabs/inspr/example/kafkasa/delete:latest -f topic/delete/delete.Dockerfile ../..
+	docker push gcr.io/insprlabs/inspr/example/kafkasa/delete:latest

--- a/examples/kafka_standalone/Makefile
+++ b/examples/kafka_standalone/Makefile
@@ -4,6 +4,9 @@ build:
 
 	docker build -t gcr.io/insprlabs/inspr/example/kafkasa/delete:latest -f topic/delete/delete.Dockerfile ../..
 	docker push gcr.io/insprlabs/inspr/example/kafkasa/delete:latest
-	
+
+	docker build -t gcr.io/insprlabs/inspr/example/kafkasa/reader:latest -f reader/reader.Dockerfile ../..
+	docker push gcr.io/insprlabs/inspr/example/kafkasa/reader:latest
+
 	docker build -t gcr.io/insprlabs/inspr/example/kafkasa/writer:latest -f writer/writer.Dockerfile ../..
 	docker push gcr.io/insprlabs/inspr/example/kafkasa/writer:latest

--- a/examples/kafka_standalone/Makefile
+++ b/examples/kafka_standalone/Makefile
@@ -1,5 +1,9 @@
 build:
 	docker build -t gcr.io/insprlabs/inspr/example/kafkasa/create:latest -f topic/create/create.Dockerfile ../..
 	docker push gcr.io/insprlabs/inspr/example/kafkasa/create:latest
+
 	docker build -t gcr.io/insprlabs/inspr/example/kafkasa/delete:latest -f topic/delete/delete.Dockerfile ../..
 	docker push gcr.io/insprlabs/inspr/example/kafkasa/delete:latest
+	
+	docker build -t gcr.io/insprlabs/inspr/example/kafkasa/writer:latest -f writer/writer.Dockerfile ../..
+	docker push gcr.io/insprlabs/inspr/example/kafkasa/writer:latest

--- a/examples/kafka_standalone/deployAll.sh
+++ b/examples/kafka_standalone/deployAll.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+
+kubectl create namespace kafkasa
+kubectl apply -n kafkasa -f ./topic/create/create.yaml
+kubectl apply -n kafkasa -f ./reader/reader.yaml
+kubectl apply -n kafkasa -f ./writer/writer.yaml

--- a/examples/kafka_standalone/reader/reader.Dockerfile
+++ b/examples/kafka_standalone/reader/reader.Dockerfile
@@ -3,7 +3,6 @@ WORKDIR /app
 COPY go.mod go.mod
 RUN go mod download
 COPY . .
-# RUN go build -o main examples/kafka_standalone/topic/create.go
 
 WORKDIR /app/examples/kafka_standalone/reader
 RUN go build -o main -tags musl reader.go

--- a/examples/kafka_standalone/reader/reader.Dockerfile
+++ b/examples/kafka_standalone/reader/reader.Dockerfile
@@ -1,0 +1,14 @@
+FROM gcr.io/insprlabs/inspr/sidecar/kafka:build AS build
+WORKDIR /app
+COPY go.mod go.mod
+RUN go mod download
+COPY . .
+# RUN go build -o main examples/kafka_standalone/topic/create.go
+
+WORKDIR /app/examples/kafka_standalone/reader
+RUN go build -o main -tags musl reader.go
+
+FROM alpine AS final
+WORKDIR /app
+COPY --from=build /app/examples/kafka_standalone/reader/main .
+CMD ./main

--- a/examples/kafka_standalone/reader/reader.go
+++ b/examples/kafka_standalone/reader/reader.go
@@ -1,0 +1,1 @@
+package main

--- a/examples/kafka_standalone/reader/reader.go
+++ b/examples/kafka_standalone/reader/reader.go
@@ -1,1 +1,41 @@
 package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/confluentinc/confluent-kafka-go/kafka"
+	"inspr.dev/inspr/examples/kafka_standalone/vars"
+)
+
+func main() {
+	consumer, err := kafka.NewConsumer(&kafka.ConfigMap{
+		"bootstrap.servers": vars.BootstrapServers,
+		"group.id":          "foo",
+		"auto.offset.reset": "earliest"})
+	if err != nil {
+		fmt.Printf("Failed to create consumer: %s\n", err.Error())
+		return
+	}
+
+	consumer.Subscribe(vars.Topic, nil)
+
+	run := true
+	for run {
+		ev := consumer.Poll(0)
+		switch e := ev.(type) {
+		case *kafka.Message:
+			fmt.Printf("%% Message on %s:\n%s\n",
+				e.TopicPartition, string(e.Value))
+		case kafka.PartitionEOF:
+			fmt.Printf("%% Reached %v\n", e)
+		case kafka.Error:
+			fmt.Fprintf(os.Stderr, "%% Error: %v\n", e)
+			run = false
+		default:
+			fmt.Printf("Ignored %v\n", e)
+		}
+	}
+
+	consumer.Close()
+}

--- a/examples/kafka_standalone/reader/reader.go
+++ b/examples/kafka_standalone/reader/reader.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/confluentinc/confluent-kafka-go/kafka"
+	"gopkg.in/confluentinc/confluent-kafka-go.v1/kafka"
 	"inspr.dev/inspr/examples/kafka_standalone/vars"
 )
 

--- a/examples/kafka_standalone/reader/reader.yaml
+++ b/examples/kafka_standalone/reader/reader.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: reader-deployment
+  labels:
+    app: reader
+
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: reader
+  template:
+    metadata:
+      labels:
+        app: reader
+
+    spec:
+      containers:
+        - name: reader
+          image: gcr.io/insprlabs/inspr/example/kafkasa/reader:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 80

--- a/examples/kafka_standalone/removeAll.sh
+++ b/examples/kafka_standalone/removeAll.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+kubectl apply -n kafkasa -f ./topic/create/create.yaml
+sleep 10s
+kubectl delete namespace kafkasa

--- a/examples/kafka_standalone/topic/create/create.Dockerfile
+++ b/examples/kafka_standalone/topic/create/create.Dockerfile
@@ -3,7 +3,6 @@ WORKDIR /app
 COPY go.mod go.mod
 RUN go mod download
 COPY . .
-# RUN go build -o main examples/kafka_standalone/topic/create.go
 
 WORKDIR /app/examples/kafka_standalone/topic/create
 RUN go build -o main -tags musl create.go

--- a/examples/kafka_standalone/topic/create/create.Dockerfile
+++ b/examples/kafka_standalone/topic/create/create.Dockerfile
@@ -1,0 +1,14 @@
+FROM gcr.io/insprlabs/inspr/sidecar/kafka:build AS build
+WORKDIR /app
+COPY go.mod go.mod
+RUN go mod download
+COPY . .
+# RUN go build -o main examples/kafka_standalone/topic/create.go
+
+WORKDIR /app/examples/kafka_standalone/topic/create
+RUN go build -o main -tags musl create.go
+
+FROM alpine AS final
+WORKDIR /app
+COPY --from=build /app/examples/kafka_standalone/topic/create/main .
+CMD ./main

--- a/examples/kafka_standalone/topic/create/create.go
+++ b/examples/kafka_standalone/topic/create/create.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"gopkg.in/confluentinc/confluent-kafka-go.v1/kafka"
+	"inspr.dev/inspr/examples/kafka_standalone/vars"
+)
+
+func main() {
+	kafkaConfig := &kafka.ConfigMap{
+		"bootstrap.servers": vars.BootstrapServers,
+	}
+
+	adminClient, err := kafka.NewAdminClient(kafkaConfig)
+	if err != nil {
+		fmt.Println(err.Error())
+		return
+	}
+
+	configs := []kafka.TopicSpecification{
+		{
+			Topic:             vars.Topic,
+			NumPartitions:     vars.NumPartitions,
+			ReplicationFactor: vars.ReplicationFactor,
+		},
+	}
+	_, err = adminClient.CreateTopics(context.Background(), configs)
+	if err != nil {
+		fmt.Println(err.Error())
+		return
+	}
+}

--- a/examples/kafka_standalone/topic/create/create.yaml
+++ b/examples/kafka_standalone/topic/create/create.yaml
@@ -1,0 +1,14 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: create-test-topic
+
+spec:
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: create-test-topic
+        image: gcr.io/insprlabs/inspr/example/kafkasa/create:latest
+        imagePullPolicy: IfNotPresent
+  backoffLimit: 4

--- a/examples/kafka_standalone/topic/delete/delete.Dockerfile
+++ b/examples/kafka_standalone/topic/delete/delete.Dockerfile
@@ -1,0 +1,14 @@
+FROM gcr.io/insprlabs/inspr/sidecar/kafka:build AS build
+WORKDIR /app
+COPY go.mod go.mod
+RUN go mod download
+COPY . .
+# RUN go build -o main examples/kafka_standalone/topic/create.go
+
+WORKDIR /app/examples/kafka_standalone/topic/delete
+RUN go build -o main -tags musl delete.go
+
+FROM alpine AS final
+WORKDIR /app
+COPY --from=build /app/examples/kafka_standalone/topic/delete/main .
+CMD ./main

--- a/examples/kafka_standalone/topic/delete/delete.Dockerfile
+++ b/examples/kafka_standalone/topic/delete/delete.Dockerfile
@@ -3,7 +3,6 @@ WORKDIR /app
 COPY go.mod go.mod
 RUN go mod download
 COPY . .
-# RUN go build -o main examples/kafka_standalone/topic/create.go
 
 WORKDIR /app/examples/kafka_standalone/topic/delete
 RUN go build -o main -tags musl delete.go

--- a/examples/kafka_standalone/topic/delete/delete.go
+++ b/examples/kafka_standalone/topic/delete/delete.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"gopkg.in/confluentinc/confluent-kafka-go.v1/kafka"
+	"inspr.dev/inspr/examples/kafka_standalone/vars"
+)
+
+func main() {
+	kafkaConfig := &kafka.ConfigMap{
+		"bootstrap.servers": vars.BootstrapServers,
+	}
+
+	adminClient, err := kafka.NewAdminClient(kafkaConfig)
+
+	if err != nil {
+		fmt.Println(err.Error())
+		return
+	}
+	_, err = adminClient.DeleteTopics(context.Background(), []string{vars.Topic})
+	if err != nil {
+		fmt.Println(err.Error())
+		return
+	}
+}

--- a/examples/kafka_standalone/topic/delete/delete.yaml
+++ b/examples/kafka_standalone/topic/delete/delete.yaml
@@ -1,0 +1,14 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: delete-test-topic
+
+spec:
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: delete-test-topic
+        image: gcr.io/insprlabs/inspr/example/kafkasa/delete:latest
+        imagePullPolicy: IfNotPresent
+  backoffLimit: 4

--- a/examples/kafka_standalone/vars/vars.go
+++ b/examples/kafka_standalone/vars/vars.go
@@ -1,0 +1,6 @@
+package vars
+
+var Topic string = "test-topic"
+var BootstrapServers string = "kafka.default.svc:9092"
+var NumPartitions int = 1
+var ReplicationFactor int = 1

--- a/examples/kafka_standalone/writer/writer.Dockerfile
+++ b/examples/kafka_standalone/writer/writer.Dockerfile
@@ -1,0 +1,14 @@
+FROM gcr.io/insprlabs/inspr/sidecar/kafka:build AS build
+WORKDIR /app
+COPY go.mod go.mod
+RUN go mod download
+COPY . .
+# RUN go build -o main examples/kafka_standalone/topic/create.go
+
+WORKDIR /app/examples/kafka_standalone/writer
+RUN go build -o main -tags musl writer.go
+
+FROM alpine AS final
+WORKDIR /app
+COPY --from=build /app/examples/kafka_standalone/writer/main .
+CMD ./main

--- a/examples/kafka_standalone/writer/writer.Dockerfile
+++ b/examples/kafka_standalone/writer/writer.Dockerfile
@@ -3,7 +3,6 @@ WORKDIR /app
 COPY go.mod go.mod
 RUN go mod download
 COPY . .
-# RUN go build -o main examples/kafka_standalone/topic/create.go
 
 WORKDIR /app/examples/kafka_standalone/writer
 RUN go build -o main -tags musl writer.go

--- a/examples/kafka_standalone/writer/writer.go
+++ b/examples/kafka_standalone/writer/writer.go
@@ -35,15 +35,20 @@ func main() {
 	time.Sleep(5 * time.Second)
 
 	// delivery_chan := make(chan kafka.Event, 10000)
-	err = p.Produce(&kafka.Message{
-		TopicPartition: kafka.TopicPartition{
-			Topic:     &vars.Topic,
-			Partition: kafka.PartitionAny},
-		Value: []byte("hello_world")},
-		nil,
-	)
-	if err != nil {
-		fmt.Printf("Failed to produce message: %s\n", err.Error())
-		return
+
+	run := true
+	for run {
+		err = p.Produce(&kafka.Message{
+			TopicPartition: kafka.TopicPartition{
+				Topic:     &vars.Topic,
+				Partition: kafka.PartitionAny},
+			Value: []byte("hello_world")},
+			nil,
+		)
+		if err != nil {
+			fmt.Printf("Failed to produce message: %s\n", err.Error())
+			run = false
+			return
+		}
 	}
 }

--- a/examples/kafka_standalone/writer/writer.go
+++ b/examples/kafka_standalone/writer/writer.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/confluentinc/confluent-kafka-go/kafka"
+	"gopkg.in/confluentinc/confluent-kafka-go.v1/kafka"
 	"inspr.dev/inspr/examples/kafka_standalone/vars"
 )
 

--- a/examples/kafka_standalone/writer/writer.go
+++ b/examples/kafka_standalone/writer/writer.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/confluentinc/confluent-kafka-go/kafka"
+	"inspr.dev/inspr/examples/kafka_standalone/vars"
+)
+
+func main() {
+
+	p, err := kafka.NewProducer(&kafka.ConfigMap{
+		"bootstrap.servers": vars.BootstrapServers,
+	})
+
+	if err != nil {
+		fmt.Printf("Failed to create producer: %s\n", err.Error())
+		return
+	}
+
+	go func() {
+		for e := range p.Events() {
+			switch ev := e.(type) {
+			case *kafka.Message:
+				if ev.TopicPartition.Error != nil {
+					fmt.Printf("Failed to deliver message: %v\n", ev.TopicPartition)
+				} else {
+					fmt.Printf("Successfully produced record to topic %s partition [%d] @ offset %v\n",
+						*ev.TopicPartition.Topic, ev.TopicPartition.Partition, ev.TopicPartition.Offset)
+				}
+			}
+		}
+	}()
+
+	// delivery_chan := make(chan kafka.Event, 10000)
+	err = p.Produce(&kafka.Message{
+		TopicPartition: kafka.TopicPartition{
+			Topic:     &vars.Topic,
+			Partition: kafka.PartitionAny},
+		Value: []byte("hello_world")},
+		nil,
+	)
+	if err != nil {
+		fmt.Printf("Failed to produce message: %s\n", err.Error())
+		return
+	}
+}

--- a/examples/kafka_standalone/writer/writer.go
+++ b/examples/kafka_standalone/writer/writer.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/confluentinc/confluent-kafka-go/kafka"
 	"inspr.dev/inspr/examples/kafka_standalone/vars"
@@ -31,6 +32,7 @@ func main() {
 			}
 		}
 	}()
+	time.Sleep(5 * time.Second)
 
 	// delivery_chan := make(chan kafka.Event, 10000)
 	err = p.Produce(&kafka.Message{

--- a/examples/kafka_standalone/writer/writer.go
+++ b/examples/kafka_standalone/writer/writer.go
@@ -34,8 +34,6 @@ func main() {
 	}()
 	time.Sleep(5 * time.Second)
 
-	// delivery_chan := make(chan kafka.Event, 10000)
-
 	run := true
 	for run {
 		err = p.Produce(&kafka.Message{

--- a/examples/kafka_standalone/writer/writer.yaml
+++ b/examples/kafka_standalone/writer/writer.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: writer-deployment
+  labels:
+    app: writer
+
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: writer
+  template:
+    metadata:
+      labels:
+        app: writer
+
+    spec:
+      containers:
+        - name: writer
+          image: gcr.io/insprlabs/inspr/example/kafkasa/writer:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - containerPort: 80


### PR DESCRIPTION
# Description

Kind: Story

Section: Examples

Summary: An example of write-read kafka dapps without the use of Inspr

## Changelog
- feature:
  - implemented k8s job for creating "kafka-test" topic on kafka
  - implemented k8s job for deleting "kafka-test" topic on kafka
  - implemented k8s deployment for app that sends messages non stop on "kafka-test" topic
  - implemented k8s deployment for app that reads messages non stop from "kafka-test" topic
  - created Makefile and dockerfiles to compile images 
## Pay attention to

> Important parts of the code that require special attention


