### PR TITLE
Bug CORE-615 | Describe command problems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ external-dns*.yaml
 # Custom notes for each developer
 my-notes.md
 
+# Custom script for each developer
+my-script.sh
+
 # Binaries build via make skaffold/build
 bin/
 tags.out

--- a/cmd/insprctl/cli/apply_dapp.go
+++ b/cmd/insprctl/cli/apply_dapp.go
@@ -98,6 +98,12 @@ func recursiveSchemaInjection(app *meta.App) error {
 		alias.Meta.Name = aliasName
 	}
 
+	if app.Spec.Node.Spec.Image != "" {
+		if app.Spec.Node.Spec.Replicas == 0 {
+			app.Spec.Node.Spec.Replicas = 1
+		}
+	}
+
 	for appName, childApp := range app.Spec.Apps {
 		childApp.Meta.Name = appName
 		err = recursiveSchemaInjection(childApp)

--- a/cmd/insprd/operators/nodes/converter.go
+++ b/cmd/insprd/operators/nodes/converter.go
@@ -393,12 +393,17 @@ func overwritePortEnvs(app *meta.App) k8s.ContainerOption {
 				Name:  "INSPR_LBSIDECAR_WRITE_PORT",
 				Value: strconv.Itoa(lbWritePort),
 			})
+		} else {
+			app.Spec.Node.Spec.SidecarPort.LBWrite, _ = strconv.Atoi(os.Getenv("INSPR_LBSIDECAR_WRITE_PORT"))
 		}
+
 		if lbReadPort > 0 {
 			c.Env = append(c.Env, corev1.EnvVar{
 				Name:  "INSPR_LBSIDECAR_READ_PORT",
 				Value: strconv.Itoa(lbReadPort),
 			})
+		} else {
+			app.Spec.Node.Spec.SidecarPort.LBRead, _ = strconv.Atoi(os.Getenv("INSPR_LBSIDECAR_READ_PORT"))
 		}
 
 	}

--- a/examples/python/route_demo/yamls/route-demo.yaml
+++ b/examples/python/route_demo/yamls/route-demo.yaml
@@ -13,7 +13,6 @@ spec:
         logLevel: debug
         node:
           spec:
-            replicas: 1
             image: gcr.io/insprlabs/inspr/example/python/client:latest
     api:
       meta:

--- a/pkg/meta/utils/format.go
+++ b/pkg/meta/utils/format.go
@@ -67,7 +67,7 @@ func PrintAppTree(app *meta.App, out io.Writer) {
 		if len(app.Spec.Node.Spec.Ports) > 0 {
 			ports := spec.Add("Ports")
 			for index, nodePort := range app.Spec.Node.Spec.Ports {
-				npIndex := ports.Add(strconv.Itoa(index))
+				npIndex := ports.Add("Port " + strconv.Itoa(index+1))
 				npIndex.Add(fmt.Sprintf("Port: %d", nodePort.Port))
 				npIndex.Add(fmt.Sprintf("TargetPort: %d", nodePort.TargetPort))
 			}


### PR DESCRIPTION
# Description

Kind: Bug

Section: node converter and apply app(cli)

Summary: Fixed sidecar ports not showing correctly. Also set node replicas default to 1 and added the "Port" prefix when describing ports.

## Changelog

* update gitignore to ignore for a "my-script.sh" file
* update node sidecar port definitions with the default if none was specified
* added "Port" prefix to the describe command when listing the node ports
* if a node has no replicas, make it equal to 1.


